### PR TITLE
Temporarily disable apiserver+etcd

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,16 +18,17 @@ builds:
     - arm64
     - ppc64le
     - s390x
-  - id: catalogd-server
-    main: ./cmd/apiserver/
-    binary: bin/apiserver
-    goos:
-    - linux
-    goarch:
-    - amd64
-    - arm64
-    - ppc64le
-    - s390x
+  # TODO: When the apiserver is working properly, uncomment this
+  # - id: catalogd-server
+  #   main: ./cmd/apiserver/
+  #   binary: bin/apiserver
+  #   goos:
+  #   - linux
+  #   goarch:
+  #   - amd64
+  #   - arm64
+  #   - ppc64le
+  #   - s390x
 dockers:
 - image_templates:
   - "{{ .Env.CONTROLLER_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-amd64"
@@ -49,26 +50,27 @@ dockers:
   dockerfile: controller.Dockerfile
   goos: linux
   goarch: s390x
-- image_templates:
-  - "{{ .Env.APISERVER_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-amd64"
-  dockerfile: apiserver.Dockerfile
-  goos: linux
-  goarch: amd64
-- image_templates:
-    - "{{ .Env.APISERVER_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-arm64"
-  dockerfile: apiserver.Dockerfile
-  goos: linux
-  goarch: arm64
-- image_templates:
-    - "{{ .Env.APISERVER_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-ppc64le"
-  dockerfile: apiserver.Dockerfile
-  goos: linux
-  goarch: ppc64le
-- image_templates:
-    - "{{ .Env.APISERVER_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-s390x"
-  dockerfile: apiserver.Dockerfile
-  goos: linux
-  goarch: s390x
+# TODO: When the apiserver is working properly, uncomment this:
+# - image_templates:
+#   - "{{ .Env.APISERVER_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-amd64"
+#   dockerfile: apiserver.Dockerfile
+#   goos: linux
+#   goarch: amd64
+# - image_templates:
+#     - "{{ .Env.APISERVER_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-arm64"
+#   dockerfile: apiserver.Dockerfile
+#   goos: linux
+#   goarch: arm64
+# - image_templates:
+#     - "{{ .Env.APISERVER_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-ppc64le"
+#   dockerfile: apiserver.Dockerfile
+#   goos: linux
+#   goarch: ppc64le
+# - image_templates:
+#     - "{{ .Env.APISERVER_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-s390x"
+#   dockerfile: apiserver.Dockerfile
+#   goos: linux
+#   goarch: s390x
 docker_manifests:
 - name_template: "{{ .Env.CONTROLLER_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}"
   image_templates:
@@ -76,12 +78,13 @@ docker_manifests:
     - "{{ .Env.CONTROLLER_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-arm64"
     - "{{ .Env.CONTROLLER_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-ppc64le"
     - "{{ .Env.CONTROLLER_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-s390x"
-- name_template: "{{ .Env.APISERVER_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}"
-  image_templates:
-    - "{{ .Env.APISERVER_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-amd64"
-    - "{{ .Env.APISERVER_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-arm64"
-    - "{{ .Env.APISERVER_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-ppc64le"
-    - "{{ .Env.APISERVER_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-s390x"
+# TODO: When the apiserver is working properly, uncomment this:
+# - name_template: "{{ .Env.APISERVER_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}"
+#   image_templates:
+#     - "{{ .Env.APISERVER_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-amd64"
+#     - "{{ .Env.APISERVER_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-arm64"
+#     - "{{ .Env.APISERVER_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-ppc64le"
+#     - "{{ .Env.APISERVER_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-s390x"
 release:
   disable: '{{ ne .Env.ENABLE_RELEASE_PIPELINE "true" }}'
   extra_files:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -15,7 +15,8 @@ resources:
 - ../crd
 - ../rbac
 - ../manager
-- ../apiserver
-- ../etcd
+# TODO: When the apiserver is working properly, uncomment this
+# - ../apiserver
+# - ../etcd
 patches:
 - path: manager_auth_proxy_patch.yaml

--- a/config/rbac/apiserver_service_account.yaml
+++ b/config/rbac/apiserver_service_account.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: serviceaccount
+    app.kuberentes.io/instance: apiserver
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: catalogd
+    app.kubernetes.io/part-of: catalogd
+    app.kubernetes.io/managed-by: kustomize
+  name: apiserver
+  namespace: system

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -16,5 +16,7 @@ resources:
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
-- apiserver_role.yaml
-- apiserver_rolebindings.yaml
+# TODO: When the apiserver is working properly, uncomment the following lines:
+# - apiserver_role.yaml
+# - apiserver_rolebindings.yaml
+# - apiserver_service_account.yaml

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -10,16 +10,3 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager
   namespace: system
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  labels:
-    app.kubernetes.io/name: serviceaccount
-    app.kuberentes.io/instance: apiserver
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: catalogd
-    app.kubernetes.io/part-of: catalogd
-    app.kubernetes.io/managed-by: kustomize
-  name: apiserver
-  namespace: system


### PR DESCRIPTION
**Description**:
- Comment out all references and things related to the custom apiserver and etcd
- Slightly out of scope but I also updated the `make quickstart` target to use `$(KUSTOMIZE)` instead of `kubectl kustomize`

**Motivation**:
- resolves #28 
