### PR TITLE
add version information

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,6 +18,8 @@ builds:
     - arm64
     - ppc64le
     - s390x
+    ldflags:
+    - -X {{ .Env.VERSION_PKG }}.gitVersion={{ .Env.GIT_VERSION }}
   # TODO: When the apiserver is working properly, uncomment this
   # - id: catalogd-server
   #   main: ./cmd/apiserver/
@@ -29,6 +31,11 @@ builds:
   #   - arm64
   #   - ppc64le
   #   - s390x
+  #   ldflags:
+  #   - -X {{ .Env.VERSION_PKG }}.gitVersion={{ .Env.GIT_VERSION }}
+  #   - -X {{ .Env.VERSION_PKG }}.gitCommit={{ .Env.GIT_COMMIT }}
+  #   - -X {{ .Env.VERSION_PKG }}.gitTreeState={{ .Env.GIT_TREE_STATE }}
+  #   - -X {{ .Env.VERSION_PKG }}.buildDate={{ .Env.BUILD_DATE }}
 dockers:
 - image_templates:
   - "{{ .Env.CONTROLLER_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-amd64"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,7 +35,7 @@ builds:
   #   - -X {{ .Env.VERSION_PKG }}.gitVersion={{ .Env.GIT_VERSION }}
   #   - -X {{ .Env.VERSION_PKG }}.gitCommit={{ .Env.GIT_COMMIT }}
   #   - -X {{ .Env.VERSION_PKG }}.gitTreeState={{ .Env.GIT_TREE_STATE }}
-  #   - -X {{ .Env.VERSION_PKG }}.buildDate={{ .Env.BUILD_DATE }}
+  #   - -X {{ .Env.VERSION_PKG }}.commitDate={{ .Env.COMMIT_DATE }}
 dockers:
 - image_templates:
   - "{{ .Env.CONTROLLER_IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-amd64"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 # Build info
 GIT_COMMIT              ?= $(shell git rev-parse HEAD)
 GIT_VERSION             ?= $(shell git describe --tags --always --dirty)
-GIT_TREE_STATE          ?= $(shell [[ -z $(git status --porcelain) ]] && echo "clean" || echo "dirty")
+GIT_STATUS				?= $(shell git status --porcelain)
+GIT_TREE_STATE          ?= $(shell [ -z "${GIT_STATUS}" ] && echo "clean" || echo "dirty")
 BUILD_DATE              ?= $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 ORG                     ?= github.com/operator-framework
 REPO                    ?= $(ORG)/catalogd

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ BUILD_DATE              ?= $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 ORG                     ?= github.com/operator-framework
 REPO                    ?= $(ORG)/catalogd
 VERSION_PKG             ?= $(REPO)/internal/version
-CTRL_VERSION_FLAGS      ?= -ldflags "-X $(VERSION_PKG).gitVersion=$(GIT_VERSION)"
-SERVER_VERSION_FLAGS    ?= -ldflags "-X $(VERSION_PKG).gitVersion=$(GIT_VERSION) -X $(VERSION_PKG).gitCommit=$(GIT_COMMIT) -X $(VERSION_PKG).gitTreeState=$(GIT_TREE_STATE) -X $(VERSION_PKG).buildDate=$(BUILD_DATE)"
+CTRL_VERSION_FLAGS      ?= -ldflags="-X '$(VERSION_PKG).gitVersion=$(GIT_VERSION)'"
+SERVER_VERSION_FLAGS    ?= -ldflags "-X '$(VERSION_PKG).gitVersion=$(GIT_VERSION)' -X '$(VERSION_PKG).gitCommit=$(GIT_COMMIT)' -X '$(VERSION_PKG).gitTreeState=$(GIT_TREE_STATE)' -X '$(VERSION_PKG).buildDate=$(BUILD_DATE)'"
 GO_BUILD_TAGS           ?= upstream
 # Image URL to use all building/pushing controller image targets
 CONTROLLER_IMG          ?= quay.io/operator-framework/catalogd-controller
@@ -164,11 +164,23 @@ wait:
 ##@ Release
 
 export ENABLE_RELEASE_PIPELINE ?= false
+<<<<<<< HEAD
 export GORELEASER_ARGS ?= --snapshot --clean
 export CONTROLLER_IMAGE_REPO ?= $(CONTROLLER_IMG)
 # TODO: When the apiserver is working properly, uncomment this line:
 # export APISERVER_IMAGE_REPO ?= $(SERVER_IMG)
 export IMAGE_TAG ?= $(IMG_TAG)
+=======
+export GORELEASER_ARGS         ?= --snapshot --clean
+export CONTROLLER_IMAGE_REPO   ?= $(CONTROLLER_IMG)
+export APISERVER_IMAGE_REPO    ?= $(SERVER_IMG)
+export IMAGE_TAG               ?= $(IMG_TAG)
+export VERSION_PKG             ?= $(VERSION_PKG)
+export GIT_VERSION             ?= $(GIT_VERSION)
+export GIT_COMMIT              ?= $(GIT_COMMIT)
+export GIT_TREE_STATE          ?= $(GIT_TREE_STATE)
+export BUILD_DATE              ?= $(BUILD_DATE)
+>>>>>>> 6403277 (update goreleaser to set version flags)
 release: goreleaser ## Runs goreleaser for catalogd. By default, this will run only as a snapshot and will not publish any artifacts unless it is run with different arguments. To override the arguments, run with "GORELEASER_ARGS=...". When run as a github action from a tag, this target will publish a full release.
 	$(GORELEASER) $(GORELEASER_ARGS)
 
@@ -184,11 +196,11 @@ $(TOOLS_BIN_DIR):
 	mkdir -p $(TOOLS_BIN_DIR)
 
 
-KUSTOMIZE_VERSION ?= v5.0.1
-KIND_VERSION ?= v0.15.0
+KUSTOMIZE_VERSION        ?= v5.0.1
+KIND_VERSION             ?= v0.15.0
 CONTROLLER_TOOLS_VERSION ?= v0.10.0
-GORELEASER_VERSION ?= v1.16.2
-ENVTEST_VERSION ?= latest
+GORELEASER_VERSION       ?= v1.16.2
+ENVTEST_VERSION          ?= latest
 
 ##@ hack/tools:
 

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,12 @@ GIT_COMMIT              ?= $(shell git rev-parse HEAD)
 GIT_VERSION             ?= $(shell git describe --tags --always --dirty)
 GIT_STATUS				?= $(shell git status --porcelain)
 GIT_TREE_STATE          ?= $(shell [ -z "${GIT_STATUS}" ] && echo "clean" || echo "dirty")
-BUILD_DATE              ?= $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+COMMIT_DATE             ?= $(shell git show -s --date=format:'%Y-%m-%dT%H:%M:%SZ' --format=%cd)
 ORG                     ?= github.com/operator-framework
 REPO                    ?= $(ORG)/catalogd
 VERSION_PKG             ?= $(REPO)/internal/version
-CTRL_VERSION_FLAGS      ?= -ldflags="-X '$(VERSION_PKG).gitVersion=$(GIT_VERSION)'"
-SERVER_VERSION_FLAGS    ?= -ldflags "-X '$(VERSION_PKG).gitVersion=$(GIT_VERSION)' -X '$(VERSION_PKG).gitCommit=$(GIT_COMMIT)' -X '$(VERSION_PKG).gitTreeState=$(GIT_TREE_STATE)' -X '$(VERSION_PKG).buildDate=$(BUILD_DATE)'"
+CTRL_LDFLAGS            ?= -ldflags="-X '$(VERSION_PKG).gitVersion=$(GIT_VERSION)'"
+SERVER_LDFLAGS          ?= -ldflags "-X '$(VERSION_PKG).gitVersion=$(GIT_VERSION)' -X '$(VERSION_PKG).gitCommit=$(GIT_COMMIT)' -X '$(VERSION_PKG).gitTreeState=$(GIT_TREE_STATE)' -X '$(VERSION_PKG).commitDate=$(COMMIT_DATE)'"
 GO_BUILD_TAGS           ?= upstream
 # Image URL to use all building/pushing controller image targets
 CONTROLLER_IMG          ?= quay.io/operator-framework/catalogd-controller
@@ -82,12 +82,12 @@ verify: tidy fmt generate ## Verify the current code generation and lint
 
 .PHONY: build-controller
 build-controller: generate fmt vet ## Build manager binary.
-	CGO_ENABLED=0 GOOS=linux go build -tags $(GO_BUILD_TAGS) $(CTRL_VERSION_FLAGS) -o bin/manager cmd/manager/main.go
+	CGO_ENABLED=0 GOOS=linux go build -tags $(GO_BUILD_TAGS) $(CTRL_LDFLAGS) -o bin/manager cmd/manager/main.go
 
 # TODO: When the apiserver is working properly, uncomment this target:
 # .PHONY: build-server
 # build-server: fmt vet ## Build api-server binary.
-# 	CGO_ENABLED=0 GOOS=linux go build -tags $(GO_BUILD_TAGS) $(SERVER_VERSION_FLAGS) -o bin/apiserver cmd/apiserver/main.go
+# 	CGO_ENABLED=0 GOOS=linux go build -tags $(GO_BUILD_TAGS) $(SERVER_LDFLAGS) -o bin/apiserver cmd/apiserver/main.go
 
 .PHONY: run
 run: generate fmt vet ## Run a controller from your host.
@@ -173,7 +173,7 @@ export VERSION_PKG             ?= $(VERSION_PKG)
 export GIT_VERSION             ?= $(GIT_VERSION)
 export GIT_COMMIT              ?= $(GIT_COMMIT)
 export GIT_TREE_STATE          ?= $(GIT_TREE_STATE)
-export BUILD_DATE              ?= $(BUILD_DATE)
+export COMMIT_DATE             ?= $(COMMIT_DATE)
 release: goreleaser ## Runs goreleaser for catalogd. By default, this will run only as a snapshot and will not publish any artifacts unless it is run with different arguments. To override the arguments, run with "GORELEASER_ARGS=...". When run as a github action from a tag, this target will publish a full release.
 	$(GORELEASER) $(GORELEASER_ARGS)
 

--- a/Makefile
+++ b/Makefile
@@ -164,23 +164,16 @@ wait:
 ##@ Release
 
 export ENABLE_RELEASE_PIPELINE ?= false
-<<<<<<< HEAD
-export GORELEASER_ARGS ?= --snapshot --clean
-export CONTROLLER_IMAGE_REPO ?= $(CONTROLLER_IMG)
-# TODO: When the apiserver is working properly, uncomment this line:
-# export APISERVER_IMAGE_REPO ?= $(SERVER_IMG)
-export IMAGE_TAG ?= $(IMG_TAG)
-=======
 export GORELEASER_ARGS         ?= --snapshot --clean
 export CONTROLLER_IMAGE_REPO   ?= $(CONTROLLER_IMG)
-export APISERVER_IMAGE_REPO    ?= $(SERVER_IMG)
+# TODO: When the apiserver is working properly, uncomment this line:
+# export APISERVER_IMAGE_REPO ?= $(SERVER_IMG)
 export IMAGE_TAG               ?= $(IMG_TAG)
 export VERSION_PKG             ?= $(VERSION_PKG)
 export GIT_VERSION             ?= $(GIT_VERSION)
 export GIT_COMMIT              ?= $(GIT_COMMIT)
 export GIT_TREE_STATE          ?= $(GIT_TREE_STATE)
 export BUILD_DATE              ?= $(BUILD_DATE)
->>>>>>> 6403277 (update goreleaser to set version flags)
 release: goreleaser ## Runs goreleaser for catalogd. By default, this will run only as a snapshot and will not publish any artifacts unless it is run with different arguments. To override the arguments, run with "GORELEASER_ARGS=...". When run as a github action from a tag, this target will publish a full release.
 	$(GORELEASER) $(GORELEASER_ARGS)
 

--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -17,14 +17,17 @@ limitations under the License.
 package main
 
 import (
-	"k8s.io/apiserver/pkg/server"
 	"k8s.io/klog"
 	"sigs.k8s.io/apiserver-runtime/pkg/builder"
 
 	// +kubebuilder:scaffold:resource-imports
-	"github.com/operator-framework/catalogd/internal/version"
+
 	corev1beta1 "github.com/operator-framework/catalogd/pkg/apis/core/v1beta1"
 )
+
+// TODO: We can't properly set the version for the APIServer using the apiserver-runtime
+// package because they hardcode the version here: https://github.com/kubernetes-sigs/apiserver-runtime/blob/33c90185692756252ad3e36c5a940167d0de8f41/internal/sample-apiserver/pkg/apiserver/apiserver.go#L86-L89
+// To be able to update this we would need to create a PR to fix it OR create the apiserver w/o using the apiserver-runtime tooling
 
 func main() {
 	err := builder.APIServer.
@@ -32,10 +35,6 @@ func main() {
 		WithResource(&corev1beta1.Package{}).
 		WithResource(&corev1beta1.BundleMetadata{}).
 		WithResource(&corev1beta1.CatalogSource{}).
-		WithConfigFns(func(config *server.RecommendedConfig) *server.RecommendedConfig {
-			config.Version = version.ApiserverVersion()
-			return config
-		}).
 		Execute()
 	if err != nil {
 		klog.Fatal(err)

--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -17,10 +17,12 @@ limitations under the License.
 package main
 
 import (
+	"k8s.io/apiserver/pkg/server"
 	"k8s.io/klog"
 	"sigs.k8s.io/apiserver-runtime/pkg/builder"
 
 	// +kubebuilder:scaffold:resource-imports
+	"github.com/operator-framework/catalogd/internal/version"
 	corev1beta1 "github.com/operator-framework/catalogd/pkg/apis/core/v1beta1"
 )
 
@@ -30,6 +32,10 @@ func main() {
 		WithResource(&corev1beta1.Package{}).
 		WithResource(&corev1beta1.BundleMetadata{}).
 		WithResource(&corev1beta1.CatalogSource{}).
+		WithConfigFns(func(config *server.RecommendedConfig) *server.RecommendedConfig {
+			config.Version = version.ApiserverVersion()
+			return config
+		}).
 		Execute()
 	if err != nil {
 		klog.Fatal(err)

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -31,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	"github.com/operator-framework/catalogd/internal/version"
 	"github.com/operator-framework/catalogd/pkg/apis/core/v1beta1"
 	corecontrollers "github.com/operator-framework/catalogd/pkg/controllers/core"
 	"github.com/operator-framework/catalogd/pkg/profile"
@@ -50,11 +52,14 @@ func init() {
 }
 
 func main() {
-	var metricsAddr string
-	var enableLeaderElection bool
-	var probeAddr string
-	var opmImage string
-	var profiling bool
+	var (
+		metricsAddr          string
+		enableLeaderElection bool
+		probeAddr            string
+		opmImage             string
+		profiling            bool
+		catalogdVersion      bool
+	)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -65,8 +70,14 @@ func main() {
 		Development: true,
 	}
 	flag.BoolVar(&profiling, "profiling", false, "enable profiling endpoints to allow for using pprof")
+	flag.BoolVar(&catalogdVersion, "version", false, "print the catalogd version and exit")
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
+
+	if catalogdVersion {
+		fmt.Printf("catalogd version: %s", version.ControllerVersion())
+		os.Exit(0)
+	}
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,33 @@
+package version
+
+import (
+	"fmt"
+	"runtime"
+
+	genericversion "k8s.io/apimachinery/pkg/version"
+)
+
+var (
+	gitVersion   = "v0.0.0-master+$Format:%h$"
+	gitCommit    = "$Format:%H$"          // sha1 from git, output of $(git rev-parse HEAD)
+	gitTreeState = ""                     // state of git tree, either "clean" or "dirty"
+	buildDate    = "1970-01-01T00:00:00Z" // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+)
+
+// ControllerVersion returns a version string for the controller
+func ControllerVersion() string {
+	return gitVersion
+}
+
+// ApiserverVersion returns a version.Info object for the apiserver
+func ApiserverVersion() genericversion.Info {
+	return genericversion.Info{
+		GitVersion:   gitVersion,
+		GitCommit:    gitCommit,
+		GitTreeState: gitTreeState,
+		BuildDate:    buildDate,
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -20,8 +20,8 @@ func ControllerVersion() string {
 }
 
 // ApiserverVersion returns a version.Info object for the apiserver
-func ApiserverVersion() genericversion.Info {
-	return genericversion.Info{
+func ApiserverVersion() *genericversion.Info {
+	return &genericversion.Info{
 		GitVersion:   gitVersion,
 		GitCommit:    gitCommit,
 		GitTreeState: gitTreeState,

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -8,10 +8,10 @@ import (
 )
 
 var (
-	gitVersion   = "v0.0.0-master+$Format:%h$"
-	gitCommit    = "$Format:%H$"          // sha1 from git, output of $(git rev-parse HEAD)
-	gitTreeState = ""                     // state of git tree, either "clean" or "dirty"
-	buildDate    = "1970-01-01T00:00:00Z" // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+	gitVersion   = "unknown"
+	gitCommit    = "unknown" // sha1 from git, output of $(git rev-parse HEAD)
+	gitTreeState = "unknown" // state of git tree, either "clean" or "dirty"
+	commitDate   = "unknown" // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
 )
 
 // ControllerVersion returns a version string for the controller
@@ -25,7 +25,7 @@ func ApiserverVersion() *genericversion.Info {
 		GitVersion:   gitVersion,
 		GitCommit:    gitCommit,
 		GitTreeState: gitTreeState,
-		BuildDate:    buildDate,
+		BuildDate:    commitDate,
 		GoVersion:    runtime.Version(),
 		Compiler:     runtime.Compiler,
 		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),


### PR DESCRIPTION
**Description**:
- Adds an internal version package with:
    - A function for getting the controller version information
    - A function for getting the apiserver version information
- Updates the Makefile to set the necessary version flags when building
- Adds a `--version` flag to the controller manager
- Updates goreleaser to set the version flags when building the controller and apiserver

- In a follow up, we will have to configure the version information for the apiserver. The `apiserver-runtime` package that we are currently using to build the apiserver hardcodes version information that overrides any of the information we include. I left a TODO comment to reflect this. A solution is to update the `apiserver-runtime` tooling OR create or own implementation that we use to set the version info. This can likely be addressed as part of #39 when we configure the apiserver to work properly.

**Motivation**:
- resolves #27  