### PR TITLE
(fix): export the CERT_MGR_VERSION env var for releasing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,7 @@ export GIT_VERSION             ?= $(GIT_VERSION)
 export GIT_COMMIT              ?= $(GIT_COMMIT)
 export GIT_TREE_STATE          ?= $(GIT_TREE_STATE)
 export COMMIT_DATE             ?= $(COMMIT_DATE)
+export CERT_MGR_VERSION        ?= $(CERT_MGR_VERSION)
 release: goreleaser ## Runs goreleaser for catalogd. By default, this will run only as a snapshot and will not publish any artifacts unless it is run with different arguments. To override the arguments, run with "GORELEASER_ARGS=...". When run as a github action from a tag, this target will publish a full release.
 	$(GORELEASER) $(GORELEASER_ARGS)
 


### PR DESCRIPTION
**Description**
- Update the Makefile to export the `CERT_MGR_VERSION` environment variable when releasing

**Motivation**
- fix the problem encountered when trying to cut the v0.1.0 release: https://github.com/operator-framework/catalogd/actions/runs/4757675157/jobs/8454773378#step:7:257