### PR TITLE
fix the quickstart target's version replacement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ release: goreleaser ## Runs goreleaser for catalogd. By default, this will run o
 	$(GORELEASER) $(GORELEASER_ARGS)
 
 quickstart: kustomize generate ## Generate the installation release manifests and scripts
-	$(KUSTOMIZE) build config/default | sed "s/:devel/:$(VERSION)/g" > catalogd.yaml
+	$(KUSTOMIZE) build config/default | sed "s/:devel/:$(GIT_VERSION)/g" > catalogd.yaml
 	
 ################
 # Hack / Tools #


### PR DESCRIPTION
**Description**
- `make quickstart` used the wrong variable for version replacement in the Makefile. This PR fixes that.

**Motivation**
- The v0.1.1 release is uninstallable due to the version tag missing from the catalogd-controller deployment