### PR TITLE
respect cluster image pull configurations

### DIFF
--- a/pkg/controllers/core/catalogsource_controller.go
+++ b/pkg/controllers/core/catalogsource_controller.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"path/filepath"
 	"time"
 
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
@@ -395,7 +396,7 @@ func (r *CatalogSourceReconciler) unpackJob(cs *corev1beta1.CatalogSource) *batc
 							Command: []string{
 								"cp",
 								"/bin/opm",
-								fmt.Sprintf("%s%s", mountPath, "opm"),
+								filepath.Join(mountPath, "opm"),
 							},
 							VolumeMounts: []v1.VolumeMount{
 								{
@@ -410,7 +411,7 @@ func (r *CatalogSourceReconciler) unpackJob(cs *corev1beta1.CatalogSource) *batc
 							Image: cs.Spec.Image,
 							Name:  "unpacker",
 							Command: []string{
-								fmt.Sprintf("%s%s", mountPath, "opm"),
+								filepath.Join(mountPath, "opm"),
 								"render",
 								"configs/",
 							},

--- a/pkg/controllers/core/catalogsource_controller.go
+++ b/pkg/controllers/core/catalogsource_controller.go
@@ -413,7 +413,7 @@ func (r *CatalogSourceReconciler) unpackJob(cs *corev1beta1.CatalogSource) *batc
 							Command: []string{
 								filepath.Join(mountPath, "opm"),
 								"render",
-								"configs/",
+								"/configs/",
 							},
 							VolumeMounts: []v1.VolumeMount{
 								{


### PR DESCRIPTION
**Description**
- When creating an unpack job use init containers to pull the catalog image, populate a volume with fbc configs, and use the opm image to render the configs from the volume. This ensures we are respecting the cluster pull configurations by not pulling an image within the unpack pod.

**Motivation**
- fixes #21