### PR TITLE
(bugfix): in Makefile set `BUILDDEPS = $(GORELEASER)`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ BINARIES=manager
 LINUX_BINARIES=$(join $(addprefix linux/,$(BINARIES)), )
 
 BUILDCMD = sh -c 'mkdir -p $(BUILDBIN) && $(GORELEASER) build $(GORELEASER_ARGS) --id $(notdir $@) --single-target -o $(BUILDBIN)/$(notdir $@)'
-BUILDDEPS = goreleaser
+BUILDDEPS = $(GORELEASER)
 
 .PHONY: build
 build: $(BINARIES)  ## Build all project binaries for the local OS and architecture.


### PR DESCRIPTION
When trying to run `make build-container` I ran into an issue where the `goreleaser` target was not found. This was due to https://github.com/operator-framework/catalogd/blob/abc5a780b4cc2700bf897f8c26015b097c892636/Makefile#L81 not being updated to be `$(GORELEASER)` to work with the bingo change introduced by #75 