### PR TITLE
chore: fix link to `config/etcd` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # catalogd
 
-This repository is a prototype for a custom apiserver that uses a (dedicated ectd instance)[configs/etcd] to serve [FBC](https://olm.operatorframework.io/docs/reference/file-based-catalogs/#docs) content on cluster in a Kubernetes native way on cluster.
+This repository is a prototype for a custom apiserver that uses a [dedicated ectd instance](config/etcd) to serve [FBC](https://olm.operatorframework.io/docs/reference/file-based-catalogs/#docs) content on cluster in a Kubernetes native way on cluster.
 
 
 ## Enhacement 


### PR DESCRIPTION
The correct syntax for a link in GitHub Markdown would be: `[text](relative/path)`

See: https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#links