### PR TITLE
Add feature gates infrastructure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,11 @@ require (
 	github.com/onsi/ginkgo/v2 v2.9.7
 	github.com/onsi/gomega v1.27.7
 	github.com/operator-framework/operator-registry v1.26.3
+	github.com/spf13/pflag v1.0.5
 	k8s.io/api v0.26.0
 	k8s.io/apimachinery v0.26.0
 	k8s.io/client-go v0.26.0
+	k8s.io/component-base v0.26.0
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
 	sigs.k8s.io/controller-runtime v0.14.0
 )
@@ -57,7 +59,6 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
@@ -76,7 +77,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.26.0 // indirect
-	k8s.io/component-base v0.26.0 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -1,0 +1,21 @@
+package features
+
+import (
+	"k8s.io/component-base/featuregate"
+)
+
+const (
+// Add new feature gates constants (strings)
+// Ex: SomeFeature featuregate.Feature = "SomeFeature"
+)
+
+var catalogdFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	// Add new feature gate definitions
+	// Ex: SomeFeature: {...}
+}
+
+var CatalogdFeatureGate featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
+
+func init() {
+	CatalogdFeatureGate.Add(catalogdFeatureGates)
+}


### PR DESCRIPTION
## Description
- Adds a new package called `features` that contains the infrastructure required for adding feature gates to catalogd
- Refactors the catalogd controller flags to enable adding the `--feature-gate` flag

## Motivation
- Allow us to get started and used to using feature gates early