### PR TITLE
bump to go 1.20

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version-file: "go.mod"
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/operator-framework/catalogd
 
-go 1.19
+go 1.20
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
Bump go.mod files and GHA workflows to use go 1.20
