### PR TITLE
Updates GH Actions to avoid using deprecated node

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -28,7 +28,7 @@ jobs:
 
     - name: Docker Login
       if: ${{ github.event_name != 'pull_request' }}
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
@@ -53,7 +53,7 @@ jobs:
         fi
     - name: Create release manifests
       run: make quickstart
-      
+
     - name: Run goreleaser
       run: make release
       env:


### PR DESCRIPTION
Updates GH actions to versions which use Node 16.

Currently some of our actions produce the following warning:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The above is due to usage of actions/checkout@v2.

`docker/login-action@v1` also seems to have another issue:

> The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/