### PR TITLE
add PSA labels to namespace for baseline enforcement

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -9,6 +9,8 @@ metadata:
     app.kubernetes.io/created-by: catalogd
     app.kubernetes.io/part-of: catalogd
     app.kubernetes.io/managed-by: kustomize
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: latest
   name: system
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
Ideally, we would enforce restricted. However, some catalog images may not be compatible with restriced enforcement.

This is another motivation for us to treat catalog images differently from runnable images. PSA compatibility of catalog images should never be a consideration because we only need to extract static files from them. Actually running them should never be necessary.