### PR TITLE
(docs) Fix link and misspelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 Catalogd is a Kubernetes extension that unpacks [file-based catalog (FBC)](https://olm.operatorframework.io/docs/reference/file-based-catalogs/#docs) content for on-cluster clients. Currently, catalogd unpacks FBC content that is packaged and distributed as container images. The catalogd road map includes plans for unpacking other content sources, such as Git repositories and OCI artifacts. For more information, see the catalogd [issues](https://github.com/operator-framework/catalogd/issues/) page. 
 
-Catalogd helps customers discover installable content by hosting catalog metadata for Kubernetes extensions, such as Operators and controllers. For more information on the Operator Lifecycle Manager (OLM) v1 suite of microservices, see the [documentation](https://github.com/operator-framework/operator-controller/docs/) for the Operator Controller.
+Catalogd helps customers discover installable content by hosting catalog metadata for Kubernetes extensions, such as Operators and controllers. For more information on the Operator Lifecycle Manager (OLM) v1 suite of microservices, see the [documentation](https://github.com/operator-framework/operator-controller/tree/main/docs) for the Operator Controller.
 
 ## Quick start 
 
-**NOTE:** Procedure steps marked with an astericks (`*`) are likely to change with future API updates.
+**NOTE:** Procedure steps marked with an asterisk (`*`) are likely to change with future API updates.
 
 1. To install catalogd, navigate to the [releases](https://github.com/operator-framework/catalogd/releases/) page, and follow the install instructions included in the release you want to install.
 


### PR DESCRIPTION
The operator-controller docs link was 404ing, now it links directly to a markdown file.