### PR TITLE
(feature): Add a minimal client library for fetching catalog contents

### DIFF
--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -1,0 +1,101 @@
+package httpclient
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/operator-framework/operator-registry/alpha/declcfg"
+)
+
+const OnClusterBaseURL = "http://catalogd-catalogserver.catalogd-system.svc"
+const catalogsEndpoint = "catalogs"
+
+// FilterFunc is used to filter declcfg.Meta objects returned
+// from a CatalogServerClient.GetCatalogContents call.
+// A return value of "true" means it should be included in the
+// response.
+type FilterFunc func(meta *declcfg.Meta) bool
+
+// CatalogServerClient is an interface that can be used for
+// fetching catalog contents from the catalogd HTTP server
+type CatalogServerClient interface {
+	// GetCatalogContents fetches contents for a provided Catalog name
+	// from the catalogd HTTP server that serves catalog contents and returns
+	// the results as a slice of *declcfg.Meta. Filters can be applied to filter
+	// the results that are returned. If any of the filters return a "false" value
+	// indicating the *declcfg.Meta object will not be included in the returned slice.
+	// An error will be returned if any occur.
+	GetCatalogContents(ctx context.Context, catalogName string, filters ...FilterFunc) ([]*declcfg.Meta, error)
+}
+
+type clientOpts func(c *client)
+
+// WithBaseURL is an option function that
+// sets the base url that is used when
+// making a request. If this option is not used
+// it defaults to OnClusterBaseURL
+func WithBaseURL(base string) clientOpts {
+	return func(c *client) {
+		c.BaseUrl = base
+	}
+}
+
+// NewClient returns a new CatalogServerClient configured
+// with the provided options (if any provided)
+func NewClient(opts ...clientOpts) CatalogServerClient {
+	cli := &client{
+		BaseUrl: OnClusterBaseURL,
+	}
+
+	for _, opt := range opts {
+		opt(cli)
+	}
+
+	return cli
+}
+
+// client is an implementation of the CatalogServerClient interface
+type client struct {
+	BaseUrl string
+}
+
+func (c *client) GetCatalogContents(ctx context.Context, catalogName string, filters ...FilterFunc) ([]*declcfg.Meta, error) {
+	catalogUrl := strings.Join([]string{c.BaseUrl, catalogsEndpoint, catalogName, "all.json"}, "/")
+
+	resp, err := http.Get(catalogUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+	if resp.StatusCode > 299 {
+		return nil, fmt.Errorf("error: response status code is %d with a response body of %s", resp.StatusCode, resp.Body)
+	}
+
+	blobs := []*declcfg.Meta{}
+	err = declcfg.WalkMetasReader(resp.Body, func(meta *declcfg.Meta, err error) error {
+		if err != nil {
+			return fmt.Errorf("error parsing catalog content from response body: %w", err)
+		}
+
+		skip := false
+		for _, filter := range filters {
+			if !filter(meta) {
+				skip = true
+			}
+		}
+
+		if !skip {
+			blobs = append(blobs, meta)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return blobs, nil
+}

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -1,6 +1,7 @@
 package httpclient
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -17,35 +18,23 @@ const catalogsEndpoint = "catalogs"
 // response.
 type FilterFunc func(meta *declcfg.Meta) bool
 
-// CatalogServerClient is an interface that can be used for
-// fetching catalog contents from the catalogd HTTP server
-type CatalogServerClient interface {
-	// GetCatalogContents fetches contents for a provided Catalog name
-	// from the catalogd HTTP server that serves catalog contents and returns
-	// the results as a slice of *declcfg.Meta. Filters can be applied to filter
-	// the results that are returned. If any of the filters return a "false" value
-	// indicating the *declcfg.Meta object will not be included in the returned slice.
-	// An error will be returned if any occur.
-	GetCatalogContents(catalogName string, filters ...FilterFunc) ([]*declcfg.Meta, error)
-}
-
-type ClientOpts func(c *client)
+type ClientOpts func(c *Client)
 
 // WithBaseURL is an option function that
 // sets the base url that is used when
 // making a request. If this option is not used
 // it defaults to OnClusterBaseURL
 func WithBaseURL(base string) ClientOpts {
-	return func(c *client) {
-		c.BaseURL = base
+	return func(c *Client) {
+		c.baseURL = base
 	}
 }
 
-// NewClient returns a new CatalogServerClient configured
+// NewClient returns a new Client configured
 // with the provided options (if any provided)
-func NewClient(opts ...ClientOpts) CatalogServerClient {
-	cli := &client{
-		BaseURL: OnClusterBaseURL,
+func NewClient(opts ...ClientOpts) *Client {
+	cli := &Client{
+		baseURL: OnClusterBaseURL,
 	}
 
 	for _, opt := range opts {
@@ -55,16 +44,26 @@ func NewClient(opts ...ClientOpts) CatalogServerClient {
 	return cli
 }
 
-// client is an implementation of the CatalogServerClient interface
-type client struct {
-	BaseURL string
+// Client is used for fetching catalog contents from the catalogd HTTP server
+type Client struct {
+	baseURL string
 }
 
-func (c *client) GetCatalogContents(catalogName string, filters ...FilterFunc) ([]*declcfg.Meta, error) {
-	catalogURL := strings.Join([]string{c.BaseURL, catalogsEndpoint, catalogName, "all.json"}, "/")
+// GetCatalogContents fetches contents for a provided Catalog name
+// from the catalogd HTTP server that serves catalog contents and returns
+// the results as a slice of *declcfg.Meta. Filters can be applied to filter
+// the results that are returned. If any of the filters return a "false" value
+// indicating the *declcfg.Meta object will not be included in the returned slice.
+// An error will be returned if any occur.
+func (c *Client) GetCatalogContents(ctx context.Context, catalogName string, filters ...FilterFunc) ([]*declcfg.Meta, error) {
+	catalogURL := strings.Join([]string{c.baseURL, catalogsEndpoint, catalogName, "all.json"}, "/")
 
-	//nolint:gosec
-	resp, err := http.Get(catalogURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, catalogURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error forming request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -1,7 +1,6 @@
 package httpclient
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -27,26 +26,26 @@ type CatalogServerClient interface {
 	// the results that are returned. If any of the filters return a "false" value
 	// indicating the *declcfg.Meta object will not be included in the returned slice.
 	// An error will be returned if any occur.
-	GetCatalogContents(ctx context.Context, catalogName string, filters ...FilterFunc) ([]*declcfg.Meta, error)
+	GetCatalogContents(catalogName string, filters ...FilterFunc) ([]*declcfg.Meta, error)
 }
 
-type clientOpts func(c *client)
+type ClientOpts func(c *client)
 
 // WithBaseURL is an option function that
 // sets the base url that is used when
 // making a request. If this option is not used
 // it defaults to OnClusterBaseURL
-func WithBaseURL(base string) clientOpts {
+func WithBaseURL(base string) ClientOpts {
 	return func(c *client) {
-		c.BaseUrl = base
+		c.BaseURL = base
 	}
 }
 
 // NewClient returns a new CatalogServerClient configured
 // with the provided options (if any provided)
-func NewClient(opts ...clientOpts) CatalogServerClient {
+func NewClient(opts ...ClientOpts) CatalogServerClient {
 	cli := &client{
-		BaseUrl: OnClusterBaseURL,
+		BaseURL: OnClusterBaseURL,
 	}
 
 	for _, opt := range opts {
@@ -58,13 +57,14 @@ func NewClient(opts ...clientOpts) CatalogServerClient {
 
 // client is an implementation of the CatalogServerClient interface
 type client struct {
-	BaseUrl string
+	BaseURL string
 }
 
-func (c *client) GetCatalogContents(ctx context.Context, catalogName string, filters ...FilterFunc) ([]*declcfg.Meta, error) {
-	catalogUrl := strings.Join([]string{c.BaseUrl, catalogsEndpoint, catalogName, "all.json"}, "/")
+func (c *client) GetCatalogContents(catalogName string, filters ...FilterFunc) ([]*declcfg.Meta, error) {
+	catalogURL := strings.Join([]string{c.BaseURL, catalogsEndpoint, catalogName, "all.json"}, "/")
 
-	resp, err := http.Get(catalogUrl)
+	//nolint:gosec
+	resp, err := http.Get(catalogURL)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -53,7 +53,7 @@ type Client struct {
 // from the catalogd HTTP server that serves catalog contents and returns
 // the results as a slice of *declcfg.Meta. Filters can be applied to filter
 // the results that are returned. If any of the filters return a "false" value
-// indicating the *declcfg.Meta object will not be included in the returned slice.
+// the *declcfg.Meta object will not be included in the returned slice.
 // An error will be returned if any occur.
 func (c *Client) GetCatalogContents(ctx context.Context, catalogName string, filters ...FilterFunc) ([]*declcfg.Meta, error) {
 	catalogURL := strings.Join([]string{c.baseURL, catalogsEndpoint, catalogName, "all.json"}, "/")

--- a/pkg/httpclient/client_test.go
+++ b/pkg/httpclient/client_test.go
@@ -2,7 +2,6 @@ package httpclient
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -27,7 +26,7 @@ var _ = Describe("HTTP Client Test", func() {
 			mux.Handle(
 				fmt.Sprintf("/catalogs/%s/all.json", testCatalogName),
 				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					_, _ = w.Write([]byte(allJson))
+					_, _ = w.Write([]byte(allJSON))
 				},
 				))
 			srv = httptest.NewServer(mux)
@@ -39,7 +38,7 @@ var _ = Describe("HTTP Client Test", func() {
 
 		It("Should return all contents", func() {
 			expectedMetas := []*declcfg.Meta{}
-			err := declcfg.WalkMetasReader(bytes.NewReader([]byte(allJson)), func(meta *declcfg.Meta, err error) error {
+			err := declcfg.WalkMetasReader(bytes.NewReader([]byte(allJSON)), func(meta *declcfg.Meta, err error) error {
 				if err != nil {
 					return err
 				}
@@ -48,14 +47,14 @@ var _ = Describe("HTTP Client Test", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			metas, err := cli.GetCatalogContents(context.TODO(), testCatalogName)
+			metas, err := cli.GetCatalogContents(testCatalogName)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(metas).To(Equal(expectedMetas))
 		})
 
 		It("Should return only blobs that have schema == \"olm.package\"", func() {
 			expectedMetas := []*declcfg.Meta{}
-			err := declcfg.WalkMetasReader(bytes.NewReader([]byte(allJson)), func(meta *declcfg.Meta, err error) error {
+			err := declcfg.WalkMetasReader(bytes.NewReader([]byte(allJSON)), func(meta *declcfg.Meta, err error) error {
 				if err != nil {
 					return err
 				}
@@ -66,7 +65,7 @@ var _ = Describe("HTTP Client Test", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			metas, err := cli.GetCatalogContents(context.TODO(), testCatalogName, func(meta *declcfg.Meta) bool {
+			metas, err := cli.GetCatalogContents(testCatalogName, func(meta *declcfg.Meta) bool {
 				return meta.Schema == "olm.package"
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -84,7 +83,7 @@ var _ = Describe("HTTP Client Test", func() {
 			mux.Handle(
 				fmt.Sprintf("/catalogs/%s/all.json", testCatalogName),
 				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					_, _ = w.Write([]byte(invalidJson))
+					_, _ = w.Write([]byte(invalidJSON))
 				},
 				))
 			srv = httptest.NewServer(mux)
@@ -95,7 +94,7 @@ var _ = Describe("HTTP Client Test", func() {
 		})
 
 		It("Should return an error", func() {
-			metas, err := cli.GetCatalogContents(context.TODO(), testCatalogName)
+			metas, err := cli.GetCatalogContents(testCatalogName)
 			Expect(err).To(HaveOccurred())
 			Expect(metas).To(BeNil())
 		})
@@ -122,14 +121,14 @@ var _ = Describe("HTTP Client Test", func() {
 		})
 
 		It("Should return an error", func() {
-			metas, err := cli.GetCatalogContents(context.TODO(), testCatalogName)
+			metas, err := cli.GetCatalogContents(testCatalogName)
 			Expect(err).To(HaveOccurred())
 			Expect(metas).To(BeNil())
 		})
 	})
 })
 
-const invalidJson = `
+const invalidJSON = `
 {
 	"schema": olm.package
 	"name": bar
@@ -137,7 +136,7 @@ const invalidJson = `
 }
 `
 
-const allJson = `
+const allJSON = `
 {
 	"schema": "olm.package",
 	"name": "foo",

--- a/pkg/httpclient/client_test.go
+++ b/pkg/httpclient/client_test.go
@@ -1,0 +1,162 @@
+package httpclient
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/operator-framework/operator-registry/alpha/declcfg"
+)
+
+var _ = Describe("HTTP Client Test", func() {
+	const (
+		testCatalogName = "httpclienttest"
+	)
+
+	Context("HTTP Server responds with 200 response code and a valid JSON stream", func() {
+		var (
+			srv *httptest.Server
+			cli CatalogServerClient
+		)
+		BeforeEach(func() {
+			mux := http.NewServeMux()
+			mux.Handle(
+				fmt.Sprintf("/catalogs/%s/all.json", testCatalogName),
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					_, _ = w.Write([]byte(allJson))
+				},
+				))
+			srv = httptest.NewServer(mux)
+			cli = NewClient(WithBaseURL(srv.URL))
+		})
+		AfterEach(func() {
+			srv.Close()
+		})
+
+		It("Should return all contents", func() {
+			expectedMetas := []*declcfg.Meta{}
+			err := declcfg.WalkMetasReader(bytes.NewReader([]byte(allJson)), func(meta *declcfg.Meta, err error) error {
+				if err != nil {
+					return err
+				}
+				expectedMetas = append(expectedMetas, meta)
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			metas, err := cli.GetCatalogContents(context.TODO(), testCatalogName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(metas).To(Equal(expectedMetas))
+		})
+
+		It("Should return only blobs that have schema == \"olm.package\"", func() {
+			expectedMetas := []*declcfg.Meta{}
+			err := declcfg.WalkMetasReader(bytes.NewReader([]byte(allJson)), func(meta *declcfg.Meta, err error) error {
+				if err != nil {
+					return err
+				}
+				if meta.Schema == "olm.package" {
+					expectedMetas = append(expectedMetas, meta)
+				}
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			metas, err := cli.GetCatalogContents(context.TODO(), testCatalogName, func(meta *declcfg.Meta) bool {
+				return meta.Schema == "olm.package"
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(metas).To(Equal(expectedMetas))
+		})
+	})
+
+	Context("HTTP Server responds with a 200 response code and an invalid JSON stream", func() {
+		var (
+			srv *httptest.Server
+			cli CatalogServerClient
+		)
+		BeforeEach(func() {
+			mux := http.NewServeMux()
+			mux.Handle(
+				fmt.Sprintf("/catalogs/%s/all.json", testCatalogName),
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					_, _ = w.Write([]byte(invalidJson))
+				},
+				))
+			srv = httptest.NewServer(mux)
+			cli = NewClient(WithBaseURL(srv.URL))
+		})
+		AfterEach(func() {
+			srv.Close()
+		})
+
+		It("Should return an error", func() {
+			metas, err := cli.GetCatalogContents(context.TODO(), testCatalogName)
+			Expect(err).To(HaveOccurred())
+			Expect(metas).To(BeNil())
+		})
+	})
+
+	Context("HTTP Server responds with a non-2xx response code", func() {
+		var (
+			srv *httptest.Server
+			cli CatalogServerClient
+		)
+		BeforeEach(func() {
+			mux := http.NewServeMux()
+			mux.Handle(
+				fmt.Sprintf("/catalogs/%s/all.json", testCatalogName),
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusInternalServerError)
+				},
+				))
+			srv = httptest.NewServer(mux)
+			cli = NewClient(WithBaseURL(srv.URL))
+		})
+		AfterEach(func() {
+			srv.Close()
+		})
+
+		It("Should return an error", func() {
+			metas, err := cli.GetCatalogContents(context.TODO(), testCatalogName)
+			Expect(err).To(HaveOccurred())
+			Expect(metas).To(BeNil())
+		})
+	})
+})
+
+const invalidJson = `
+{
+	"schema": olm.package
+	"name": bar
+	defaultChannel: "stable"
+}
+`
+
+const allJson = `
+{
+	"schema": "olm.package",
+	"name": "foo",
+	"defaultChannel": "alpha"
+}
+{
+	"schema": "olm.bundle",
+	"name": "foo-bundle.v0.0.1",
+	"image": "quay.io/foo-operator/foo-bundle:v.0.0.1",
+	"package": "foo"
+}
+{
+	"schema": "olm.channel",
+	"package": "foo",
+	"name": "alpha",
+	"entries": [
+		{
+			"name": "foo-bundle.v0.0.1"
+		}
+	]
+}
+`

--- a/pkg/httpclient/client_test.go
+++ b/pkg/httpclient/client_test.go
@@ -2,6 +2,7 @@ package httpclient
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -19,7 +20,7 @@ var _ = Describe("HTTP Client Test", func() {
 	Context("HTTP Server responds with 200 response code and a valid JSON stream", func() {
 		var (
 			srv *httptest.Server
-			cli CatalogServerClient
+			cli *Client
 		)
 		BeforeEach(func() {
 			mux := http.NewServeMux()
@@ -47,7 +48,7 @@ var _ = Describe("HTTP Client Test", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			metas, err := cli.GetCatalogContents(testCatalogName)
+			metas, err := cli.GetCatalogContents(context.TODO(), testCatalogName)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(metas).To(Equal(expectedMetas))
 		})
@@ -65,7 +66,7 @@ var _ = Describe("HTTP Client Test", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			metas, err := cli.GetCatalogContents(testCatalogName, func(meta *declcfg.Meta) bool {
+			metas, err := cli.GetCatalogContents(context.TODO(), testCatalogName, func(meta *declcfg.Meta) bool {
 				return meta.Schema == "olm.package"
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -76,7 +77,7 @@ var _ = Describe("HTTP Client Test", func() {
 	Context("HTTP Server responds with a 200 response code and an invalid JSON stream", func() {
 		var (
 			srv *httptest.Server
-			cli CatalogServerClient
+			cli *Client
 		)
 		BeforeEach(func() {
 			mux := http.NewServeMux()
@@ -94,7 +95,7 @@ var _ = Describe("HTTP Client Test", func() {
 		})
 
 		It("Should return an error", func() {
-			metas, err := cli.GetCatalogContents(testCatalogName)
+			metas, err := cli.GetCatalogContents(context.TODO(), testCatalogName)
 			Expect(err).To(HaveOccurred())
 			Expect(metas).To(BeNil())
 		})
@@ -103,7 +104,7 @@ var _ = Describe("HTTP Client Test", func() {
 	Context("HTTP Server responds with a non-2xx response code", func() {
 		var (
 			srv *httptest.Server
-			cli CatalogServerClient
+			cli *Client
 		)
 		BeforeEach(func() {
 			mux := http.NewServeMux()
@@ -121,7 +122,7 @@ var _ = Describe("HTTP Client Test", func() {
 		})
 
 		It("Should return an error", func() {
-			metas, err := cli.GetCatalogContents(testCatalogName)
+			metas, err := cli.GetCatalogContents(context.TODO(), testCatalogName)
 			Expect(err).To(HaveOccurred())
 			Expect(metas).To(BeNil())
 		})

--- a/pkg/httpclient/suite_test.go
+++ b/pkg/httpclient/suite_test.go
@@ -1,0 +1,13 @@
+package httpclient
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "HTTP Client Suite")
+}


### PR DESCRIPTION
**Description**
- Adds a minimal client library to facilitate fetching a `Catalog`s contents from the catalogd HTTP server
- Adds unit tests for this minimal client library

**Motivation**
- Resolves #117 