### PR TITLE
add default printer columns

### DIFF
--- a/api/core/v1alpha1/catalog_types.go
+++ b/api/core/v1alpha1/catalog_types.go
@@ -47,6 +47,8 @@ const (
 //+kubebuilder:object:root=true
 //+kubebuilder:resource:scope=Cluster
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
+//+kubebuilder:printcolumn:name=Age,type=date,JSONPath=`.metadata.creationTimestamp`
 
 // Catalog is the Schema for the Catalogs API
 type Catalog struct {

--- a/config/crd/bases/catalogd.operatorframework.io_catalogs.yaml
+++ b/config/crd/bases/catalogd.operatorframework.io_catalogs.yaml
@@ -14,7 +14,14 @@ spec:
     singular: catalog
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Catalog is the Schema for the Catalogs API


### PR DESCRIPTION
Add printer columns to catalog API. Adds Phase as well as Age printer columns

Resolves https://github.com/operator-framework/catalogd/issues/172