### PR TITLE
:seedling: replace e2e Job with client-go ProxyGet() call

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -16,11 +16,10 @@ import (
 )
 
 var (
-	cfg                    *rest.Config
-	c                      client.Client
-	err                    error
-	defaultSystemNamespace = "catalogd-system"
-	kubeClient             kubernetes.Interface
+	cfg        *rest.Config
+	c          client.Client
+	err        error
+	kubeClient kubernetes.Interface
 )
 
 func TestE2E(t *testing.T) {


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

**Description**:
- Replaces the `Job` created to query the catalogd http server with a client-go `ProxyGet()` call to directly query the service. It parses the necessary information from the `status.contentURL` field of the `Catalog` resource before making the query.

**Motivation**:
- resolves #204 

