### PR TITLE
:bug: Add enum validation for source type

### DIFF
--- a/api/core/v1alpha1/catalog_types.go
+++ b/api/core/v1alpha1/catalog_types.go
@@ -99,6 +99,7 @@ type CatalogStatus struct {
 // CatalogSource contains the sourcing information for a Catalog
 type CatalogSource struct {
 	// Type defines the kind of Catalog content being sourced.
+	// +kubebuilder:validation:Enum=image
 	Type SourceType `json:"type"`
 	// Image is the catalog image that backs the content of this catalog.
 	Image *ImageSource `json:"image,omitempty"`

--- a/config/crd/bases/catalogd.operatorframework.io_catalogs.yaml
+++ b/config/crd/bases/catalogd.operatorframework.io_catalogs.yaml
@@ -76,6 +76,8 @@ spec:
                     type: object
                   type:
                     description: Type defines the kind of Catalog content being sourced.
+                    enum:
+                    - image
                     type: string
                 required:
                 - type


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

**Description**
- Add enum validation marker for the `spec.source.type` field to fail fast at attempted creation time when an unsupported source type is specified.

**Motivation**
- Resolves #213  
