### PR TITLE
:seedling: Remove cert-manager from release note install process

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -66,7 +66,6 @@ release:
   header: |
     ## Installation
     ```bash
-    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/{{ .Env.CERT_MGR_VERSION }}/cert-manager.yaml
-    kubectl wait --for=condition=Available --namespace=cert-manager deployment/cert-manager-webhook --timeout=60s
     kubectl apply -f https://github.com/operator-framework/catalogd/releases/download/{{ .Tag }}/catalogd.yaml
+    kubectl wait --for=condition=Available --namespace=catalogd-system deployment/catalogd-controller-manager --timeout=60s
     ```


### PR DESCRIPTION

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->

**Description**:
- Removes the cert-manager references from the installation guide on the release notes published by goreleaser. catalogd has not depended on cert-manager being installed for quite some time.

**Motivation**
- Prevent users from installing unnecessary stuff if they _only_ want to install catalogd. Also prevents the idea that catalogd has some dependency on cert-manager.