### PR TITLE
:bug: bump the catalogserver write timeout to 5 minutes

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -159,10 +159,12 @@ func main() {
 	catalogServer := server.Server{
 		Kind: "catalogs",
 		Server: &http.Server{
-			Addr:         catalogServerAddr,
-			Handler:      catalogdmetrics.AddMetricsToHandler(localStorage.StorageServerHandler()),
-			ReadTimeout:  5 * time.Second,
-			WriteTimeout: 10 * time.Second,
+			Addr:        catalogServerAddr,
+			Handler:     catalogdmetrics.AddMetricsToHandler(localStorage.StorageServerHandler()),
+			ReadTimeout: 5 * time.Second,
+			// TODO: Revert this to 10 seconds if/when the API
+			// evolves to have significantly smaller responses
+			WriteTimeout: 5 * time.Minute,
 		},
 		ShutdownTimeout: &shutdownTimeout,
 	}


### PR DESCRIPTION
to allow for fully writing large catalogs contents in the response

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->
