### PR TITLE
:warning: Make catalog server serve catalog contents over HTTPS

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -66,6 +66,8 @@ release:
   header: |
     ## Installation
     ```bash
+    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.yaml
+    kubectl wait --for=condition=Available --namespace=cert-manager deployment/cert-manager-webhook --timeout=60s
     kubectl apply -f https://github.com/operator-framework/catalogd/releases/download/{{ .Tag }}/catalogd.yaml
     kubectl wait --for=condition=Available --namespace=catalogd-system deployment/catalogd-controller-manager --timeout=60s
     ```

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ kind-load: $(KIND) ## Load the built images onto the local cluster
 	$(KIND) load docker-image $(IMAGE) --name $(KIND_CLUSTER_NAME)
 
 .PHONY: install
-install: build-container kind-load deploy wait ## Install local catalogd
+install: build-container kind-load cert-manager deploy wait ## Install local catalogd
 
 .PHONY: deploy
 deploy: $(KUSTOMIZE) ## Deploy Catalogd to the K8s cluster specified in ~/.kube/config.
@@ -166,6 +166,10 @@ undeploy: $(KUSTOMIZE) ## Undeploy Catalogd from the K8s cluster specified in ~/
 wait:
 	kubectl wait --for=condition=Available --namespace=$(CATALOGD_NAMESPACE) deployment/catalogd-controller-manager --timeout=60s
 
+.PHONY: cert-manager
+cert-manager:
+	kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/${CERT_MGR_VERSION}/cert-manager.yaml
+	kubectl wait --for=condition=Available --namespace=cert-manager deployment/cert-manager-webhook --timeout=60s
 ##@ Release
 
 export ENABLE_RELEASE_PIPELINE ?= false

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -77,9 +77,11 @@ func main() {
 		catalogdVersion      bool
 		systemNamespace      string
 		catalogServerAddr    string
-		httpExternalAddr     string
+		httpsExternalAddr    string
 		cacheDir             string
 		gcInterval           time.Duration
+		certfile             string
+		keyfile              string
 	)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -89,10 +91,12 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&systemNamespace, "system-namespace", "", "The namespace catalogd uses for internal state, configuration, and workloads")
 	flag.StringVar(&catalogServerAddr, "catalogs-server-addr", ":8083", "The address where the unpacked catalogs' content will be accessible")
-	flag.StringVar(&httpExternalAddr, "http-external-address", "http://catalogd-catalogserver.catalogd-system.svc", "The external address at which the http server is reachable.")
+	flag.StringVar(&httpsExternalAddr, "https-external-address", "https://catalogd-catalogserver.catalogd-system.svc", "The external address at which the http server is reachable.")
 	flag.StringVar(&cacheDir, "cache-dir", "/var/cache/", "The directory in the filesystem that catalogd will use for file based caching")
 	flag.BoolVar(&catalogdVersion, "version", false, "print the catalogd version and exit")
 	flag.DurationVar(&gcInterval, "gc-interval", 12*time.Hour, "interval in which garbage collection should be run against the catalog content cache")
+	flag.StringVar(&certfile, "tls-cert", "/var/certs/tls.crt", "The certificate file used for serving catalog contents over HTTPS")
+	flag.StringVar(&keyfile, "tls-key", "/var/certs/tls.key", "The key file used for serving catalog contents over HTTPS")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -149,7 +153,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	baseStorageURL, err := url.Parse(fmt.Sprintf("%s/catalogs/", httpExternalAddr))
+	baseStorageURL, err := url.Parse(fmt.Sprintf("%s/catalogs/", httpsExternalAddr))
 	if err != nil {
 		setupLog.Error(err, "unable to create base storage URL")
 		os.Exit(1)
@@ -168,6 +172,9 @@ func main() {
 			WriteTimeout: 5 * time.Minute,
 		},
 		ShutdownTimeout: &shutdownTimeout,
+		ServeTLS:        true,
+		CertFile:        certfile,
+		KeyFile:         keyfile,
 	}
 
 	if err := mgr.Add(&catalogServer); err != nil {

--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -1,0 +1,19 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: catalogserver-cert
+  namespace: system
+spec:
+  secretName: catalogd-catalogserver-cert
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
+  subject:
+    organizations:
+      - operator-framework
+  isCA: false
+  dnsNames:
+    - catalogd-catalogserver.catalogd-system.svc
+  issuerRef:
+    name: catalogd-catalogserver-selfsigned-issuer
+    kind: Issuer
+

--- a/config/certmanager/issuer.yaml
+++ b/config/certmanager/issuer.yaml
@@ -1,0 +1,7 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: catalogserver-selfsigned-issuer
+  namespace: system
+spec:
+  selfSigned: {}

--- a/config/certmanager/kustomization.yaml
+++ b/config/certmanager/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- issuer.yaml
+- certificate.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -14,5 +14,5 @@ kind: Kustomization
 resources:
 - ../crd
 - ../rbac
+- ../certmanager
 - ../manager
-

--- a/config/manager/catalogserver_service.yaml
+++ b/config/manager/catalogserver_service.yaml
@@ -10,7 +10,7 @@ spec:
   selector:
     control-plane: controller-manager
   ports:
-  - name: http
+  - name: https
     protocol: TCP
-    port: 80
+    port: 443
     targetPort: 8083

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -75,12 +75,14 @@ spec:
         args:
         - --leader-elect
         - --metrics-bind-address=127.0.0.1:8080
-        - --http-external-address=http://catalogd-catalogserver.catalogd-system.svc
+        - --https-external-address=https://catalogd-catalogserver.catalogd-system.svc
         image: controller:latest
         name: manager
         volumeMounts:
             - name: cache
               mountPath: /var/cache/
+            - name: catalogserver-certs
+              mountPath: /var/certs/
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -108,3 +110,6 @@ spec:
       volumes:
         - name: cache
           emptyDir: {}
+        - name: catalogserver-certs
+          secret:
+            secretName: catalogd-catalogserver-cert

--- a/internal/third_party/server/server.go
+++ b/internal/third_party/server/server.go
@@ -62,6 +62,18 @@ type Server struct {
 	// ShutdownTimeout is an optional duration that indicates how long to wait for the server to shutdown gracefully. If not set,
 	// the server will wait indefinitely for all connections to close.
 	ShutdownTimeout *time.Duration
+
+	// ServeTLS is an optional bool that indicates that the server should
+	// serve over HTTPS
+	ServeTLS bool
+
+	// CertFile is the certificate file to use when serving over HTTPS.
+	// Only used and required when ServeTLS is "true".
+	CertFile string
+
+	// KeyFile is the key file to use when serving over HTTPS.
+	// Only used and required when ServeTLS is "true".
+	KeyFile string
 }
 
 // Start starts the server. It will block until the server is stopped or an error occurs.
@@ -116,7 +128,15 @@ func (s *Server) addr() string {
 
 func (s *Server) serve() error {
 	if s.Listener != nil {
+		if s.ServeTLS {
+			return s.Server.ServeTLS(s.Listener, s.CertFile, s.KeyFile)
+		}
 		return s.Server.Serve(s.Listener)
 	}
+
+	if s.ServeTLS {
+		return s.Server.ListenAndServeTLS(s.CertFile, s.KeyFile)
+	}
+
 	return s.Server.ListenAndServe()
 }

--- a/test/e2e/unpack_test.go
+++ b/test/e2e/unpack_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Catalog Unpacking", func() {
 			// the ProxyGet() call below needs an explicit port value, so if
 			// value from url.Port() is empty, we assume port 80.
 			if port == "" {
-				port = "80"
+				port = "443"
 			}
 			resp := kubeClient.CoreV1().Services(ns).ProxyGet(url.Scheme, name, port, url.Path, map[string]string{})
 			rc, err := resp.Stream(ctx)


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->
**Description**:
- Updates the internal `server.Server` to have options for serving contents over HTTPS
- Sets serving catalog contents over HTTPS, only configuration is the external https address, cert and key file
- Adds cert-manager as a dependency and adds cert manager resources to the config to create the necessary self-signed certificates
- Updates .goreleaser.yml to include cert-manager installation instructions since it is now a dependency again