### PR TITLE
⚠ Change default namespace to olmv1-system

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -67,5 +67,5 @@ release:
     kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.yaml
     kubectl wait --for=condition=Available --namespace=cert-manager deployment/cert-manager-webhook --timeout=60s
     kubectl apply -f https://github.com/operator-framework/catalogd/releases/download/{{ .Tag }}/catalogd.yaml
-    kubectl wait --for=condition=Available --namespace=catalogd-system deployment/catalogd-controller-manager --timeout=60s
+    kubectl wait --for=condition=Available --namespace=olmv1-system deployment/catalogd-controller-manager --timeout=60s
     ```

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ endif
 # E2E configuration
 TESTDATA_DIR := testdata
 
-CATALOGD_NAMESPACE := catalogd-system
+CATALOGD_NAMESPACE := olmv1-system
 KIND_CLUSTER_IMAGE := kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e
 
 ##@ General

--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ Procedure steps marked with an asterisk (`*`) are likely to change with future A
     Events:                    <none>
     ```
 
-1. Port forward the `catalogd-catalogserver` service in the `catalogd-system` namespace:
+1. Port forward the `catalogd-catalogserver` service in the `olmv1-system` namespace:
     ```sh
-    $ kubectl -n catalogd-system port-forward svc/catalogd-catalogserver 8080:443
+    $ kubectl -n olmv1-system port-forward svc/catalogd-catalogserver 8080:443
     ```
 
 1. Run the following command to get a list of packages:

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -84,7 +84,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&systemNamespace, "system-namespace", "", "The namespace catalogd uses for internal state, configuration, and workloads")
 	flag.StringVar(&catalogServerAddr, "catalogs-server-addr", ":8083", "The address where the unpacked catalogs' content will be accessible")
-	flag.StringVar(&externalAddr, "external-address", "catalogd-catalogserver.catalogd-system.svc", "The external address at which the http(s) server is reachable.")
+	flag.StringVar(&externalAddr, "external-address", "catalogd-catalogserver.olmv1-system.svc", "The external address at which the http(s) server is reachable.")
 	flag.StringVar(&cacheDir, "cache-dir", "/var/cache/", "The directory in the filesystem that catalogd will use for file based caching")
 	flag.BoolVar(&catalogdVersion, "version", false, "print the catalogd version and exit")
 	flag.DurationVar(&gcInterval, "gc-interval", 12*time.Hour, "interval in which garbage collection should be run against the catalog content cache")
@@ -227,7 +227,7 @@ func main() {
 func podNamespace() string {
 	namespace, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {
-		return "catalogd-system"
+		return "olmv1-system"
 	}
 	return string(namespace)
 }

--- a/config/base/default/kustomization.yaml
+++ b/config/base/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: catalogd-system
+namespace: olmv1-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named

--- a/config/base/manager/manager.yaml
+++ b/config/base/manager/manager.yaml
@@ -76,7 +76,7 @@ spec:
         args:
         - --leader-elect
         - --metrics-bind-address=127.0.0.1:8080
-        - --external-address=catalogd-catalogserver.catalogd-system.svc
+        - --external-address=catalogd-catalogserver.olmv1-system.svc
         image: controller:latest
         name: manager
         volumeMounts:

--- a/config/base/nginx-ingress/resources/nginx_ingress.yaml
+++ b/config/base/nginx-ingress/resources/nginx_ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: catalogd-ingress
-  namespace: catalogd-system
+  namespace: olmv1-system
 spec:
   ingressClassName: nginx
   rules:

--- a/config/overlays/cert-manager/kustomization.yaml
+++ b/config/overlays/cert-manager/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: catalogd-system
+namespace: olmv1-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named

--- a/config/overlays/cert-manager/resources/certificate.yaml
+++ b/config/overlays/cert-manager/resources/certificate.yaml
@@ -8,7 +8,7 @@ spec:
   secretName: catalogd-catalogserver-cert
   dnsNames:
     - localhost
-    - catalogd-catalogserver.catalogd-system.svc
+    - catalogd-catalogserver.olmv1-system.svc
   issuerRef:
     kind: Issuer
     name: catalogd-catalogserver-ca-issuer

--- a/docs/fetching-catalog-contents.md
+++ b/docs/fetching-catalog-contents.md
@@ -21,7 +21,7 @@ of a catalog can be read from:
       reason: UnpackSuccessful
       status: "True"
       type: Unpacked
-    contentURL: https://catalogd-catalogserver.catalogd-system.svc/catalogs/operatorhubio/all.json
+    contentURL: https://catalogd-catalogserver.olmv1-system.svc/catalogs/operatorhubio/all.json
     phase: Unpacked
     resolvedSource:
       image:
@@ -37,20 +37,20 @@ object.
 
 When making a request for the contents of the `operatorhubio` `ClusterCatalog` from within
 the cluster issue a HTTP `GET` request to 
-`https://catalogd-catalogserver.catalogd-system.svc/catalogs/operatorhubio/all.json`
+`https://catalogd-catalogserver.olmv1-system.svc/catalogs/operatorhubio/all.json`
 
 An example command to run a `Pod` to `curl` the catalog contents:
 ```sh
-kubectl run fetcher --image=curlimages/curl:latest -- curl https://catalogd-catalogserver.catalogd-system.svc/catalogs/operatorhubio/all.json
+kubectl run fetcher --image=curlimages/curl:latest -- curl https://catalogd-catalogserver.olmv1-system.svc/catalogs/operatorhubio/all.json
 ```
 
 ## Off cluster
 
 When making a request for the contents of the `operatorhubio` `ClusterCatalog` from outside
 the cluster, we have to perform an extra step:
-1. Port forward the `catalogd-catalogserver` service in the `catalogd-system` namespace:
+1. Port forward the `catalogd-catalogserver` service in the `olmv1-system` namespace:
 ```sh
-kubectl -n catalogd-system port-forward svc/catalogd-catalogserver 8080:443
+kubectl -n olmv1-system port-forward svc/catalogd-catalogserver 8080:443
 ```
 
 Once the service has been successfully forwarded to a localhost port, issue a HTTP `GET`
@@ -106,7 +106,7 @@ This section outlines a way of exposing the `Catalogd` Service's endpoints outsi
       kind: Ingress
       metadata:
         name: catalogd-nginx-ingress
-        namespace: catalogd-system
+        namespace: olmv1-system
       spec:
         ingressClassName: nginx
         rules:
@@ -123,7 +123,7 @@ This section outlines a way of exposing the `Catalogd` Service's endpoints outsi
     Let's verify that the `Ingress` object got created successfully from the sample by running the following command:
 
       ```sh
-        $ kubectl describe ingress/catalogd-ingress -n catalogd-system
+        $ kubectl describe ingress/catalogd-ingress -n olmv1-system
       ```
 
 1. Run the below example `curl` request to retrieve all of the catalog contents:
@@ -134,7 +134,7 @@ This section outlines a way of exposing the `Catalogd` Service's endpoints outsi
     
     To obtain `address` of the ingress object, you can run the below command and look for the value in the `ADDRESS` field from output: 
     ```sh
-      $ kubectl -n catalogd-system get ingress
+      $ kubectl -n olmv1-system get ingress
     ```
    
     You can further use the `curl` commands outlined in the [Catalogd README](https://github.com/operator-framework/catalogd/blob/main/README.md) to filter out the JSON content by list of bundles, channels & packages.

--- a/hack/scripts/demo-script.sh
+++ b/hack/scripts/demo-script.sh
@@ -9,7 +9,7 @@ sleep 10
 # install catalogd on the cluster
 # could also `make install` in repo
 kubectl apply -f https://github.com/operator-framework/catalogd/releases/latest/download/catalogd.yaml
-kubectl wait --for=condition=Available -n catalogd-system deploy/catalogd-controller-manager --timeout=60s
+kubectl wait --for=condition=Available -n olmv1-system deploy/catalogd-controller-manager --timeout=60s
 sleep 10
 # inspect crds (catalog)
 kubectl get crds -A
@@ -22,7 +22,7 @@ kubectl get catalog -A
 time kubectl wait --for=condition=Unpacked catalog/operatorhubio --timeout=1m
 
 # port forward the catalogd-catalogserver service to interact with the HTTP server serving catalog contents
-(kubectl -n catalogd-system port-forward svc/catalogd-catalogserver 8080:80)&
+(kubectl -n olmv1-system port-forward svc/catalogd-catalogserver 8080:80)&
 
 # check what 'packages' are available in this catalog
 curl http://localhost:8080/catalogs/operatorhubio/all.json | jq -s '.[] | select(.schema == "olm.package") | .name'


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->
Wasn't really sure if we considered this a major or minor change.

This changes the default namespace for Catalogd from catalogd-system to olmv1-system as part of the effort to move all OLMv1 components to the same namespace.