### PR TITLE
:bug: Fixing the labels for better identify metrics

### DIFF
--- a/config/base/manager/catalogserver_service.yaml
+++ b/config/base/manager/catalogserver_service.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: system
 spec:
   selector:
-    control-plane: controller-manager
+    control-plane: catalogd-controller-manager
   ports:
   - name: http
     protocol: TCP

--- a/config/base/manager/manager.yaml
+++ b/config/base/manager/manager.yaml
@@ -19,14 +19,14 @@ metadata:
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: catalogd-controller-manager
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: controller-manager
+        control-plane: catalogd-controller-manager
     spec:
       affinity:
         nodeAffinity:

--- a/config/base/rbac/auth_proxy_service.yaml
+++ b/config/base/rbac/auth_proxy_service.yaml
@@ -13,4 +13,4 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    control-plane: controller-manager
+    control-plane: catalogd-controller-manager


### PR DESCRIPTION
As the label selector used for both catalogd and operator-controller metrics services is "control-plane: controller-manager". Hence changing the labels in both operator-controller and catalogd to make sure we do not overlap.
Refer
https://github.com/operator-framework/operator-controller/issues/955 for details

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->
