### PR TITLE
✨ Include OperatorHub.io ClusterCatalog in releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,6 +61,7 @@ release:
   disable: '{{ ne .Env.ENABLE_RELEASE_PIPELINE "true" }}'
   extra_files:
   - glob: 'catalogd.yaml'
+  - glob: './config/base/default/clustercatalogs/operatorhub.yaml'
   header: |
     ## Installation
     ```bash
@@ -68,4 +69,9 @@ release:
     kubectl wait --for=condition=Available --namespace=cert-manager deployment/cert-manager-webhook --timeout=60s
     kubectl apply -f https://github.com/operator-framework/catalogd/releases/download/{{ .Tag }}/catalogd.yaml
     kubectl wait --for=condition=Available --namespace=olmv1-system deployment/catalogd-controller-manager --timeout=60s
+    ```
+    ## Optional OperatorHub.io Catalog Installation
+    ```
+    kubectl apply -f https://github.com/operator-framework/catalogd/releases/download/{{ .Tag }}/operatorhub.yaml
+    kubectl wait --for=condition=Unpacked clustercatalog/operatorhubio --timeout=60s
     ```

--- a/config/base/default/clustercatalogs/operatorhub.yaml
+++ b/config/base/default/clustercatalogs/operatorhub.yaml
@@ -1,0 +1,10 @@
+apiVersion: catalogd.operatorframework.io/v1alpha1
+kind: ClusterCatalog
+metadata:
+  name: operatorhubio
+  namespace: olmv1-system
+spec:
+  source:
+    type: image
+    image:
+      ref: quay.io/operatorhubio/catalog:latest


### PR DESCRIPTION
Also adds optional instructions for adding the OperatorHub.io ClusterCatalog to a cluster.

I didn't change this, but curious on thoughts regarding any changes to the README. Right now we give an example where the user copy/pastes the whole yaml file--should I change that to just reference this file instead?

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->
