### PR TITLE
🌱 Add dependabot K8s dependencies group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,8 @@ updates:
       interval: "daily"
     commit-message:
       prefix: ":seedling:"
+    groups:
+      k8s-dependencies:
+        patterns:
+        - "k8s.io/*"
+        - "sigs.k8s.io/*"


### PR DESCRIPTION
This should help group k8s dependencies into a single PR when possible.

Relevant doc: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

Similar PR in operator-controller: https://github.com/operator-framework/operator-controller/pull/1070