### PR TITLE
:bug: Removing the catalogd from  app.kubernetes.io/name

### DIFF
--- a/config/base/manager/manager.yaml
+++ b/config/base/manager/manager.yaml
@@ -3,7 +3,6 @@ kind: Namespace
 metadata:
   labels:
     app.kubernetes.io/part-of: olm
-    app.kubernetes.io/name: catalogd
     pod-security.kubernetes.io/enforce: baseline
     pod-security.kubernetes.io/enforce-version: latest
   name: system


### PR DESCRIPTION
As this namespace is shared between catalogd operator-framework-catalogd

Fixes issue #346

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->
