### PR TITLE
✨: Catalog Priority

### DIFF
--- a/api/core/v1alpha1/clustercatalog_types.go
+++ b/api/core/v1alpha1/clustercatalog_types.go
@@ -75,6 +75,11 @@ type ClusterCatalogSpec struct {
 	// source is the source of a Catalog that contains catalog metadata in the FBC format
 	// https://olm.operatorframework.io/docs/reference/file-based-catalogs/#docs
 	Source CatalogSource `json:"source"`
+
+	// priority is used as the tie-breaker between bundles selected from different catalogs; a higher number means higher priority.
+	// +kubebuilder:default:=0
+	// +optional
+	Priority int32 `json:"priority,omitempty"`
 }
 
 // ClusterCatalogStatus defines the observed state of ClusterCatalog

--- a/config/base/crd/bases/olm.operatorframework.io_clustercatalogs.yaml
+++ b/config/base/crd/bases/olm.operatorframework.io_clustercatalogs.yaml
@@ -49,6 +49,12 @@ spec:
           spec:
             description: ClusterCatalogSpec defines the desired state of ClusterCatalog
             properties:
+              priority:
+                default: 0
+                description: priority is used as the tie-breaker between bundles selected
+                  from different catalogs; a higher number means higher priority.
+                format: int32
+                type: integer
               source:
                 description: |-
                   source is the source of a Catalog that contains catalog metadata in the FBC format

--- a/config/samples/core_v1alpha1_clustercatalog.yaml
+++ b/config/samples/core_v1alpha1_clustercatalog.yaml
@@ -3,6 +3,7 @@ kind: ClusterCatalog
 metadata:
   name: operatorhubio
 spec:
+  priority: 0
   source:
     type: image
     image:


### PR DESCRIPTION
Adds an int32 field to allow users to optionally set priority of catalogs. This priority value may be taken into account during bundle selection from multiple catalogs to remove ambiguity.

Fixes: https://github.com/operator-framework/operator-controller/issues/1116

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->
