### PR TITLE
:sparkles: Remove status.phase field from the code and doc references

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ Procedure steps marked with an asterisk (`*`) are likely to change with future A
           f:status:
             .:
             f:conditions:
-            f:phase:
         Manager:         manager
         Operation:       Update
         Subresource:     status
@@ -91,7 +90,6 @@ Procedure steps marked with an asterisk (`*`) are likely to change with future A
         Reason:                Unpacking
         Status:                False
         Type:                  Unpacked
-      Phase:                   Unpacking
     Events:                    <none>
     ```
 

--- a/api/core/v1alpha1/clustercatalog_types.go
+++ b/api/core/v1alpha1/clustercatalog_types.go
@@ -35,17 +35,11 @@ const (
 	ReasonUnpackFailed        = "UnpackFailed"
 	ReasonStorageFailed       = "FailedToStore"
 	ReasonStorageDeleteFailed = "FailedToDelete"
-
-	PhasePending   = "Pending"
-	PhaseUnpacking = "Unpacking"
-	PhaseFailing   = "Failing"
-	PhaseUnpacked  = "Unpacked"
 )
 
 //+kubebuilder:object:root=true
 //+kubebuilder:resource:scope=Cluster
 //+kubebuilder:subresource:status
-//+kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 //+kubebuilder:printcolumn:name=LastUnpacked,type=date,JSONPath=`.status.lastUnpacked`
 //+kubebuilder:printcolumn:name=Age,type=date,JSONPath=`.metadata.creationTimestamp`
 
@@ -91,10 +85,6 @@ type ClusterCatalogStatus struct {
 	// resolvedSource contains information about the resolved source
 	// +optional
 	ResolvedSource *ResolvedCatalogSource `json:"resolvedSource,omitempty"`
-	// phase represents a human-readable status of resolution of the content source.
-	// It is not appropriate to use for business logic determination.
-	// +optional
-	Phase string `json:"phase,omitempty"`
 	// contentURL is a cluster-internal address that on-cluster components
 	// can read the content of a catalog from
 	// +optional

--- a/config/base/crd/bases/olm.operatorframework.io_clustercatalogs.yaml
+++ b/config/base/crd/bases/olm.operatorframework.io_clustercatalogs.yaml
@@ -15,9 +15,6 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.phase
-      name: Phase
-      type: string
     - jsonPath: .status.lastUnpacked
       name: LastUnpacked
       type: date
@@ -182,11 +179,6 @@ spec:
                   ClusterCatalog's generation, which is updated on mutation by the API Server.
                 format: int64
                 type: integer
-              phase:
-                description: |-
-                  phase represents a human-readable status of resolution of the content source.
-                  It is not appropriate to use for business logic determination.
-                type: string
               resolvedSource:
                 description: resolvedSource contains information about the resolved
                   source

--- a/docs/fetching-catalog-contents.md
+++ b/docs/fetching-catalog-contents.md
@@ -91,7 +91,6 @@ of a catalog can be read from:
       status: "True"
       type: Unpacked
     contentURL: https://catalogd-catalogserver.olmv1-system.svc/catalogs/operatorhubio/all.json
-    phase: Unpacked
     resolvedSource:
       image:
         ref: quay.io/operatorhubio/catalog@sha256:e53267559addc85227c2a7901ca54b980bc900276fc24d3f4db0549cb38ecf76

--- a/internal/controllers/core/clustercatalog_controller.go
+++ b/internal/controllers/core/clustercatalog_controller.go
@@ -186,7 +186,6 @@ func (r *ClusterCatalogReconciler) reconcile(ctx context.Context, catalog *v1alp
 
 func updateStatusUnpackPending(status *v1alpha1.ClusterCatalogStatus, result *source.Result) {
 	status.ResolvedSource = nil
-	status.Phase = v1alpha1.PhasePending
 	meta.SetStatusCondition(&status.Conditions, metav1.Condition{
 		Type:    v1alpha1.TypeUnpacked,
 		Status:  metav1.ConditionFalse,
@@ -197,7 +196,6 @@ func updateStatusUnpackPending(status *v1alpha1.ClusterCatalogStatus, result *so
 
 func updateStatusUnpacking(status *v1alpha1.ClusterCatalogStatus, result *source.Result) {
 	status.ResolvedSource = nil
-	status.Phase = v1alpha1.PhaseUnpacking
 	meta.SetStatusCondition(&status.Conditions, metav1.Condition{
 		Type:    v1alpha1.TypeUnpacked,
 		Status:  metav1.ConditionFalse,
@@ -209,7 +207,6 @@ func updateStatusUnpacking(status *v1alpha1.ClusterCatalogStatus, result *source
 func updateStatusUnpacked(status *v1alpha1.ClusterCatalogStatus, result *source.Result, contentURL string, generation int64, lastUnpacked metav1.Time) {
 	status.ResolvedSource = result.ResolvedSource
 	status.ContentURL = contentURL
-	status.Phase = v1alpha1.PhaseUnpacked
 	status.ObservedGeneration = generation
 	status.LastUnpacked = lastUnpacked
 	meta.SetStatusCondition(&status.Conditions, metav1.Condition{
@@ -222,7 +219,6 @@ func updateStatusUnpacked(status *v1alpha1.ClusterCatalogStatus, result *source.
 
 func updateStatusUnpackFailing(status *v1alpha1.ClusterCatalogStatus, err error) error {
 	status.ResolvedSource = nil
-	status.Phase = v1alpha1.PhaseFailing
 	meta.SetStatusCondition(&status.Conditions, metav1.Condition{
 		Type:    v1alpha1.TypeUnpacked,
 		Status:  metav1.ConditionFalse,
@@ -234,7 +230,6 @@ func updateStatusUnpackFailing(status *v1alpha1.ClusterCatalogStatus, err error)
 
 func updateStatusStorageError(status *v1alpha1.ClusterCatalogStatus, err error) error {
 	status.ResolvedSource = nil
-	status.Phase = v1alpha1.PhaseFailing
 	meta.SetStatusCondition(&status.Conditions, metav1.Condition{
 		Type:    v1alpha1.TypeUnpacked,
 		Status:  metav1.ConditionFalse,

--- a/internal/controllers/core/clustercatalog_controller_test.go
+++ b/internal/controllers/core/clustercatalog_controller_test.go
@@ -115,7 +115,6 @@ func TestCatalogdControllerReconcile(t *testing.T) {
 					},
 				},
 				Status: catalogdv1alpha1.ClusterCatalogStatus{
-					Phase: catalogdv1alpha1.PhaseFailing,
 					Conditions: []metav1.Condition{
 						{
 							Type:   catalogdv1alpha1.TypeUnpacked,
@@ -160,7 +159,6 @@ func TestCatalogdControllerReconcile(t *testing.T) {
 					},
 				},
 				Status: catalogdv1alpha1.ClusterCatalogStatus{
-					Phase: catalogdv1alpha1.PhasePending,
 					Conditions: []metav1.Condition{
 						{
 							Type:   catalogdv1alpha1.TypeUnpacked,
@@ -205,7 +203,6 @@ func TestCatalogdControllerReconcile(t *testing.T) {
 					},
 				},
 				Status: catalogdv1alpha1.ClusterCatalogStatus{
-					Phase: catalogdv1alpha1.PhaseUnpacking,
 					Conditions: []metav1.Condition{
 						{
 							Type:   catalogdv1alpha1.TypeUnpacked,
@@ -251,7 +248,6 @@ func TestCatalogdControllerReconcile(t *testing.T) {
 					},
 				},
 				Status: catalogdv1alpha1.ClusterCatalogStatus{
-					Phase: catalogdv1alpha1.PhaseFailing,
 					Conditions: []metav1.Condition{
 						{
 							Type:   catalogdv1alpha1.TypeUnpacked,
@@ -297,7 +293,6 @@ func TestCatalogdControllerReconcile(t *testing.T) {
 					},
 				},
 				Status: catalogdv1alpha1.ClusterCatalogStatus{
-					Phase: catalogdv1alpha1.PhaseFailing,
 					Conditions: []metav1.Condition{
 						{
 							Type:   catalogdv1alpha1.TypeUnpacked,
@@ -345,7 +340,6 @@ func TestCatalogdControllerReconcile(t *testing.T) {
 					},
 				},
 				Status: catalogdv1alpha1.ClusterCatalogStatus{
-					Phase:      catalogdv1alpha1.PhaseUnpacked,
 					ContentURL: "URL",
 					Conditions: []metav1.Condition{
 						{
@@ -397,7 +391,6 @@ func TestCatalogdControllerReconcile(t *testing.T) {
 					},
 				},
 				Status: catalogdv1alpha1.ClusterCatalogStatus{
-					Phase: catalogdv1alpha1.PhaseFailing,
 					Conditions: []metav1.Condition{
 						{
 							Type:   catalogdv1alpha1.TypeUnpacked,
@@ -650,7 +643,6 @@ func TestPollingReconcilerUnpack(t *testing.T) {
 					},
 				},
 				Status: catalogdv1alpha1.ClusterCatalogStatus{
-					Phase:      catalogdv1alpha1.PhaseUnpacked,
 					ContentURL: "URL",
 					Conditions: []metav1.Condition{
 						{
@@ -689,7 +681,6 @@ func TestPollingReconcilerUnpack(t *testing.T) {
 					},
 				},
 				Status: catalogdv1alpha1.ClusterCatalogStatus{
-					Phase:      catalogdv1alpha1.PhaseUnpacked,
 					ContentURL: "URL",
 					Conditions: []metav1.Condition{
 						{
@@ -728,7 +719,6 @@ func TestPollingReconcilerUnpack(t *testing.T) {
 					},
 				},
 				Status: catalogdv1alpha1.ClusterCatalogStatus{
-					Phase:      catalogdv1alpha1.PhaseUnpacked,
 					ContentURL: "URL",
 					Conditions: []metav1.Condition{
 						{
@@ -767,7 +757,6 @@ func TestPollingReconcilerUnpack(t *testing.T) {
 					},
 				},
 				Status: catalogdv1alpha1.ClusterCatalogStatus{
-					Phase:      catalogdv1alpha1.PhaseUnpacked,
 					ContentURL: "URL",
 					Conditions: []metav1.Condition{
 						{

--- a/test/tools/imageregistry/registry.sh
+++ b/test/tools/imageregistry/registry.sh
@@ -7,7 +7,7 @@ set -e
 # 1. Installs cert-manager for creating a self-signed certificate for the image registry
 # 2. Creates all the resources necessary for deploying the image registry in the catalogd-e2e namespace
 # 3. Creates ConfigMaps containing the test catalog + Dockerfile to be mounted to the kaniko pod
-# 4. Waits for kaniko pod to have Phase == Succeeded, indicating the test catalog image has been built + pushed
+# 4. Waits for kaniko pod to have Condition Complete == true, indicating the test catalog image has been built + pushed
 # to the test image registry
 # Usage:
 # registry.sh


### PR DESCRIPTION
Fix #366 
_Technically_ an API breakage...
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->
