### PR TITLE
:seedling: Move cert-manager.io patch into tls component

### DIFF
--- a/config/base/manager/webhook/patch.yaml
+++ b/config/base/manager/webhook/patch.yaml
@@ -8,6 +8,3 @@
 - op: add
   path: /webhooks/0/clientConfig/service/port
   value: 443
-- op: add
-  path: /metadata/annotations/cert-manager.io~1inject-ca-from-secret
-  value: cert-manager/olmv1-ca

--- a/config/components/tls/kustomization.yaml
+++ b/config/components/tls/kustomization.yaml
@@ -13,3 +13,9 @@ patches:
     kind: Deployment
     name: controller-manager
   path: patches/manager_deployment_certs.yaml
+- target:
+    group: admissionregistration.k8s.io
+    kind: MutatingWebhookConfiguration
+    name: mutating-webhook-configuration
+    version: v1
+  path: patches/catalogd_webhook.yaml

--- a/config/components/tls/patches/catalogd_webhook.yaml
+++ b/config/components/tls/patches/catalogd_webhook.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /metadata/annotations/cert-manager.io~1inject-ca-from-secret
+  value: cert-manager/olmv1-ca


### PR DESCRIPTION
Fix #371 
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->
