### PR TITLE
🌱 Add matchCondition to webhook config

### DIFF
--- a/config/base/manager/webhook/patch.yaml
+++ b/config/base/manager/webhook/patch.yaml
@@ -8,3 +8,8 @@
 - op: add
   path: /webhooks/0/clientConfig/service/port
   value: 443
+- op: add
+  path: /webhooks/0/matchConditions
+  value:
+    - name: MissingOrIncorrectMetadataNameLabel
+      expression: "!has(object.metadata.labels) || !('olm.operatorframework.io/metadata.name' in object.metadata.labels) || object.metadata.labels['olm.operatorframework.io/metadata.name'] != object.metadata.name"


### PR DESCRIPTION
Fix: #370
 
Should add some efficiency as it only lets the webhook fire when needed. 

If either the `olm.operatorframework.io/metadata.name` label is missing, or the label does not match the catalog name, the webhook will be allowed to fire and correct the situation.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->
