### PR TITLE
⚠ Status condition clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,58 +40,48 @@ Procedure steps marked with an asterisk (`*`) are likely to change with future A
     ```sh
     Name:         operatorhubio
     Namespace:    
-    Labels:       <none>
+    Labels:       olm.operatorframework.io/metadata.name=operatorhubio
     Annotations:  <none>
     API Version:  olm.operatorframework.io/v1alpha1
     Kind:         ClusterCatalog
     Metadata:
-      Creation Timestamp:  2023-06-23T18:35:13Z
-      Generation:          1
-      Managed Fields:
-        API Version:  olm.operatorframework.io/v1alpha1
-        Fields Type:  FieldsV1
-        fieldsV1:
-          f:metadata:
-            f:annotations:
-              .:
-              f:kubectl.kubernetes.io/last-applied-configuration:
-          f:spec:
-            .:
-            f:source:
-              .:
-              f:image:
-                .:
-                f:ref:
-              f:type:
-        Manager:      kubectl-client-side-apply
-        Operation:    Update
-        Time:         2023-06-23T18:35:13Z
-        API Version:  olm.operatorframework.io/v1alpha1
-        Fields Type:  FieldsV1
-        fieldsV1:
-          f:status:
-            .:
-            f:conditions:
-        Manager:         manager
-        Operation:       Update
-        Subresource:     status
-        Time:            2023-06-23T18:35:43Z
-      Resource Version:  1397
-      UID:               709cee9d-c669-46e1-97d0-e97dcce8f388
+      Creation Timestamp:  2024-09-12T13:37:04Z
+      Finalizers:
+        olm.operatorframework.io/delete-server-cache
+      Generation:        1
+      Resource Version:  961
+      UID:               fa6bb9cf-1a36-4189-a7a0-83284c3f6f55
     Spec:
+      Priority:  0
       Source:
         Image:
-          Ref:  quay.io/operatorhubio/catalog:latest
-        Type:   image
+          Poll Interval:  10m0s
+          Ref:            quay.io/operatorhubio/catalog:latest
+        Type:             image
     Status:
       Conditions:
-        Last Transition Time:  2023-06-23T18:35:13Z
-        Message:               
-        Reason:                Unpacking
+        Last Transition Time:  2024-09-12T13:37:53Z
+        Message:               Successfully unpacked and stored content from quay.io/operatorhubio/catalog:latest
+        Reason:                Succeeded
         Status:                False
-        Type:                  Unpacked
-    Events:                    <none>
-    ```
+        Type:                  Progressing
+        Last Transition Time:  2024-09-12T13:37:53Z
+        Message:               Content from quay.io/operatorhubio/catalog:latest is being served
+        Reason:                Available
+        Status:                True
+        Type:                  Serving
+      Content URL:             https://catalogd-catalogserver.olmv1-system.svc/catalogs/operatorhubio/all.json
+      Last Unpacked:           2024-09-12T13:37:52Z
+      Observed Generation:     1
+      Resolved Source:
+        Image:
+          Last Poll Attempt:  2024-09-12T13:37:52Z
+          Last Unpacked:      2024-09-12T13:37:52Z
+          Ref:                quay.io/operatorhubio/catalog:latest
+          Resolved Ref:       quay.io/operatorhubio/catalog@sha256:4453a361198d39d0390fd8c1a7f07b5a5a3ae1e8dac9979ef0c4eba46299df16
+        Type:                 image
+   Events:                   <none>
+   ```
 
 1. Port forward the `catalogd-service` service in the `olmv1-system` namespace:
     ```sh

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Procedure steps marked with an asterisk (`*`) are likely to change with future A
         Reason:                Available
         Status:                True
         Type:                  Serving
-      Content URL:             https://catalogd-catalogserver.olmv1-system.svc/catalogs/operatorhubio/all.json
+      Content URL:             https://catalogd-service.olmv1-system.svc/catalogs/operatorhubio/all.json
       Last Unpacked:           2024-09-12T13:37:52Z
       Observed Generation:     1
       Resolved Source:

--- a/api/core/v1alpha1/clustercatalog_types.go
+++ b/api/core/v1alpha1/clustercatalog_types.go
@@ -27,15 +27,17 @@ type SourceType string
 const (
 	SourceTypeImage SourceType = "image"
 
-	TypeUnpacked = "Unpacked"
-	TypeDelete   = "Delete"
+	TypeProgressing = "Progressing"
+	TypeServing     = "Serving"
 
-	ReasonUnpackPending       = "UnpackPending"
-	ReasonUnpacking           = "Unpacking"
-	ReasonUnpackSuccessful    = "UnpackSuccessful"
-	ReasonUnpackFailed        = "UnpackFailed"
-	ReasonStorageFailed       = "FailedToStore"
-	ReasonStorageDeleteFailed = "FailedToDelete"
+	// Serving reasons
+	ReasonAvailable   = "Available"
+	ReasonUnavailable = "Unavailable"
+
+	// Progressing reasons
+	ReasonSucceeded = "Succeeded"
+	ReasonRetrying  = "Retrying"
+	ReasonTerminal  = "Terminal"
 
 	MetadataNameLabel = "olm.operatorframework.io/metadata.name"
 )
@@ -44,6 +46,7 @@ const (
 //+kubebuilder:resource:scope=Cluster
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name=LastUnpacked,type=date,JSONPath=`.status.lastUnpacked`
+//+kubebuilder:printcolumn:name="Serving",type=string,JSONPath=`.status.conditions[?(@.type=="Serving")].status`
 //+kubebuilder:printcolumn:name=Age,type=date,JSONPath=`.metadata.creationTimestamp`
 
 // ClusterCatalog enables users to make File-Based Catalog (FBC) catalog data available to the cluster.

--- a/config/base/crd/bases/olm.operatorframework.io_clustercatalogs.yaml
+++ b/config/base/crd/bases/olm.operatorframework.io_clustercatalogs.yaml
@@ -18,6 +18,9 @@ spec:
     - jsonPath: .status.lastUnpacked
       name: LastUnpacked
       type: date
+    - jsonPath: .status.conditions[?(@.type=="Serving")].status
+      name: Serving
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/docs/fetching-catalog-contents.md
+++ b/docs/fetching-catalog-contents.md
@@ -84,13 +84,9 @@ of a catalog can be read from:
 
 ```yaml
   status:
-    conditions:
-    - lastTransitionTime: "2023-09-14T15:21:18Z"
-      message: successfully unpacked the catalog image "quay.io/operatorhubio/catalog@sha256:e53267559addc85227c2a7901ca54b980bc900276fc24d3f4db0549cb38ecf76"
-      reason: UnpackSuccessful
-      status: "True"
-      type: Unpacked
-    contentURL: https://catalogd-service.olmv1-system.svc/catalogs/operatorhubio/all.json
+    .
+    .
+    contentURL: https://catalogd-catalogserver.olmv1-system.svc/catalogs/operatorhubio/all.json
     resolvedSource:
       image:
         ref: quay.io/operatorhubio/catalog@sha256:e53267559addc85227c2a7901ca54b980bc900276fc24d3f4db0549cb38ecf76

--- a/internal/controllers/core/clustercatalog_controller.go
+++ b/internal/controllers/core/clustercatalog_controller.go
@@ -281,14 +281,14 @@ func NewFinalizers(localStorage storage.Instance, unpacker source.Unpacker) (crf
 		}
 		if err := localStorage.Delete(catalog.Name); err != nil {
 			updateStatusProgressing(catalog, err)
-			return crfinalizer.Result{}, err
+			return crfinalizer.Result{StatusUpdated: true}, err
 		}
 		updateStatusNotServing(&catalog.Status)
 		if err := unpacker.Cleanup(ctx, catalog); err != nil {
 			updateStatusProgressing(catalog, err)
-			return crfinalizer.Result{}, err
+			return crfinalizer.Result{StatusUpdated: true}, err
 		}
-		return crfinalizer.Result{}, nil
+		return crfinalizer.Result{StatusUpdated: true}, nil
 	}))
 	if err != nil {
 		return f, err

--- a/internal/controllers/core/clustercatalog_controller_test.go
+++ b/internal/controllers/core/clustercatalog_controller_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/fs"
 	"net/http"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	catalogdv1alpha1 "github.com/operator-framework/catalogd/api/core/v1alpha1"
 	"github.com/operator-framework/catalogd/internal/source"
@@ -27,24 +29,23 @@ type MockSource struct {
 	// result is the result that should be returned when MockSource.Unpack is called
 	result *source.Result
 
-	// shouldError determines whether or not the MockSource should return an error when MockSource.Unpack is called
-	shouldError bool
+	// error is the error to be returned when MockSource.Unpack is called
+	unpackError error
+
+	// cleanupError is the error to be returned when MockSource.Cleanup is called
+	cleanupError error
 }
 
 func (ms *MockSource) Unpack(_ context.Context, _ *catalogdv1alpha1.ClusterCatalog) (*source.Result, error) {
-	if ms.shouldError {
-		return nil, errors.New("mocksource error")
+	if ms.unpackError != nil {
+		return nil, ms.unpackError
 	}
 
 	return ms.result, nil
 }
 
 func (ms *MockSource) Cleanup(_ context.Context, _ *catalogdv1alpha1.ClusterCatalog) error {
-	if ms.shouldError {
-		return errors.New("mocksource error")
-	}
-
-	return nil
+	return ms.cleanupError
 }
 
 var _ storage.Instance = &MockStore{}
@@ -83,7 +84,7 @@ func TestCatalogdControllerReconcile(t *testing.T) {
 	for _, tt := range []struct {
 		name            string
 		catalog         *catalogdv1alpha1.ClusterCatalog
-		shouldErr       bool
+		expectedError   error
 		shouldPanic     bool
 		expectedCatalog *catalogdv1alpha1.ClusterCatalog
 		source          source.Unpacker
@@ -118,18 +119,19 @@ func TestCatalogdControllerReconcile(t *testing.T) {
 				Status: catalogdv1alpha1.ClusterCatalogStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:   catalogdv1alpha1.TypeUnpacked,
+							Type:   catalogdv1alpha1.TypeProgressing,
 							Status: metav1.ConditionFalse,
-							Reason: catalogdv1alpha1.ReasonUnpackFailed,
+							Reason: catalogdv1alpha1.ReasonTerminal,
 						},
 					},
 				},
 			},
 		},
 		{
-			name: "valid source type, unpack state == Pending, unpack state is reflected in status",
+			name:          "valid source type, unpack returns error, status updated to reflect error state and error is returned",
+			expectedError: fmt.Errorf("source bundle content: %w", fmt.Errorf("mocksource error")),
 			source: &MockSource{
-				result: &source.Result{State: source.StatePending},
+				unpackError: errors.New("mocksource error"),
 			},
 			store: &MockStore{},
 			catalog: &catalogdv1alpha1.ClusterCatalog{
@@ -162,18 +164,19 @@ func TestCatalogdControllerReconcile(t *testing.T) {
 				Status: catalogdv1alpha1.ClusterCatalogStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:   catalogdv1alpha1.TypeUnpacked,
-							Status: metav1.ConditionFalse,
-							Reason: catalogdv1alpha1.ReasonUnpackPending,
+							Type:   catalogdv1alpha1.TypeProgressing,
+							Status: metav1.ConditionTrue,
+							Reason: catalogdv1alpha1.ReasonRetrying,
 						},
 					},
 				},
 			},
 		},
 		{
-			name: "valid source type, unpack state == Unpacking, unpack state is reflected in status",
+			name:          "valid source type, unpack returns unrecoverable error, status updated to reflect unrecoverable error state and error is returned",
+			expectedError: fmt.Errorf("source bundle content: %w", reconcile.TerminalError(fmt.Errorf("mocksource Unrecoverable error"))),
 			source: &MockSource{
-				result: &source.Result{State: source.StateUnpacking},
+				unpackError: reconcile.TerminalError(errors.New("mocksource Unrecoverable error")),
 			},
 			store: &MockStore{},
 			catalog: &catalogdv1alpha1.ClusterCatalog{
@@ -206,110 +209,25 @@ func TestCatalogdControllerReconcile(t *testing.T) {
 				Status: catalogdv1alpha1.ClusterCatalogStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:   catalogdv1alpha1.TypeUnpacked,
+							Type:   catalogdv1alpha1.TypeProgressing,
 							Status: metav1.ConditionFalse,
-							Reason: catalogdv1alpha1.ReasonUnpacking,
+							Reason: catalogdv1alpha1.ReasonTerminal,
 						},
 					},
 				},
 			},
 		},
 		{
-			name:      "valid source type, unpack state is unknown, unpack state is reflected in status and error is returned",
-			shouldErr: true,
-			source: &MockSource{
-				result: &source.Result{State: "unknown"},
-			},
-			store: &MockStore{},
-			catalog: &catalogdv1alpha1.ClusterCatalog{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "catalog",
-					Finalizers: []string{fbcDeletionFinalizer},
-				},
-				Spec: catalogdv1alpha1.ClusterCatalogSpec{
-					Source: catalogdv1alpha1.CatalogSource{
-						Type: "image",
-						Image: &catalogdv1alpha1.ImageSource{
-							Ref: "someimage:latest",
-						},
-					},
-				},
-			},
-			expectedCatalog: &catalogdv1alpha1.ClusterCatalog{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "catalog",
-					Finalizers: []string{fbcDeletionFinalizer},
-				},
-				Spec: catalogdv1alpha1.ClusterCatalogSpec{
-					Source: catalogdv1alpha1.CatalogSource{
-						Type: "image",
-						Image: &catalogdv1alpha1.ImageSource{
-							Ref: "someimage:latest",
-						},
-					},
-				},
-				Status: catalogdv1alpha1.ClusterCatalogStatus{
-					Conditions: []metav1.Condition{
-						{
-							Type:   catalogdv1alpha1.TypeUnpacked,
-							Status: metav1.ConditionFalse,
-							Reason: catalogdv1alpha1.ReasonUnpackFailed,
-						},
-					},
-				},
-			},
-		},
-		{
-			name:      "valid source type, unpack returns error, status updated to reflect error state and error is returned",
-			shouldErr: true,
-			source: &MockSource{
-				shouldError: true,
-			},
-			store: &MockStore{},
-			catalog: &catalogdv1alpha1.ClusterCatalog{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "catalog",
-					Finalizers: []string{fbcDeletionFinalizer},
-				},
-				Spec: catalogdv1alpha1.ClusterCatalogSpec{
-					Source: catalogdv1alpha1.CatalogSource{
-						Type: "image",
-						Image: &catalogdv1alpha1.ImageSource{
-							Ref: "someimage:latest",
-						},
-					},
-				},
-			},
-			expectedCatalog: &catalogdv1alpha1.ClusterCatalog{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "catalog",
-					Finalizers: []string{fbcDeletionFinalizer},
-				},
-				Spec: catalogdv1alpha1.ClusterCatalogSpec{
-					Source: catalogdv1alpha1.CatalogSource{
-						Type: "image",
-						Image: &catalogdv1alpha1.ImageSource{
-							Ref: "someimage:latest",
-						},
-					},
-				},
-				Status: catalogdv1alpha1.ClusterCatalogStatus{
-					Conditions: []metav1.Condition{
-						{
-							Type:   catalogdv1alpha1.TypeUnpacked,
-							Status: metav1.ConditionFalse,
-							Reason: catalogdv1alpha1.ReasonUnpackFailed,
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "valid source type, unpack state == Unpacked, unpack state is reflected in status",
+			name: "valid source type, unpack state == Unpacked, should reflect in status that it's not progressing anymore, and is serving",
 			source: &MockSource{
 				result: &source.Result{
 					State: source.StateUnpacked,
 					FS:    &fstest.MapFS{},
+					ResolvedSource: &catalogdv1alpha1.ResolvedCatalogSource{
+						Image: &catalogdv1alpha1.ResolvedImageSource{
+							Ref: "someimage@someSHA256Digest",
+						},
+					},
 				},
 			},
 			store: &MockStore{},
@@ -344,17 +262,27 @@ func TestCatalogdControllerReconcile(t *testing.T) {
 					ContentURL: "URL",
 					Conditions: []metav1.Condition{
 						{
-							Type:   catalogdv1alpha1.TypeUnpacked,
+							Type:   catalogdv1alpha1.TypeServing,
 							Status: metav1.ConditionTrue,
-							Reason: catalogdv1alpha1.ReasonUnpackSuccessful,
+							Reason: catalogdv1alpha1.ReasonAvailable,
+						},
+						{
+							Type:   catalogdv1alpha1.TypeProgressing,
+							Status: metav1.ConditionFalse,
+							Reason: catalogdv1alpha1.ReasonSucceeded,
+						},
+					},
+					ResolvedSource: &catalogdv1alpha1.ResolvedCatalogSource{
+						Image: &catalogdv1alpha1.ResolvedImageSource{
+							Ref: "someimage@someSHA256Digest",
 						},
 					},
 				},
 			},
 		},
 		{
-			name:      "valid source type, unpack state == Unpacked, storage fails, failure reflected in status and error returned",
-			shouldErr: true,
+			name:          "valid source type, unpack state == Unpacked, storage fails, failure reflected in status and error returned",
+			expectedError: fmt.Errorf("error storing fbc: mockstore store error"),
 			source: &MockSource{
 				result: &source.Result{
 					State: source.StateUnpacked,
@@ -394,9 +322,9 @@ func TestCatalogdControllerReconcile(t *testing.T) {
 				Status: catalogdv1alpha1.ClusterCatalogStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:   catalogdv1alpha1.TypeUnpacked,
-							Status: metav1.ConditionFalse,
-							Reason: catalogdv1alpha1.ReasonStorageFailed,
+							Type:   catalogdv1alpha1.TypeProgressing,
+							Status: metav1.ConditionTrue,
+							Reason: catalogdv1alpha1.ReasonRetrying,
 						},
 					},
 				},
@@ -462,6 +390,32 @@ func TestCatalogdControllerReconcile(t *testing.T) {
 						},
 					},
 				},
+				Status: catalogdv1alpha1.ClusterCatalogStatus{
+					ContentURL:         "URL",
+					LastUnpacked:       metav1.Time{},
+					ObservedGeneration: 0,
+					ResolvedSource: &catalogdv1alpha1.ResolvedCatalogSource{
+						Type: "image",
+						Image: &catalogdv1alpha1.ResolvedImageSource{
+							Ref:             "",
+							ResolvedRef:     "",
+							LastPollAttempt: metav1.Time{},
+							LastUnpacked:    metav1.Time{},
+						},
+					},
+					Conditions: []metav1.Condition{
+						{
+							Type:   catalogdv1alpha1.TypeServing,
+							Status: metav1.ConditionTrue,
+							Reason: catalogdv1alpha1.ReasonAvailable,
+						},
+						{
+							Type:   catalogdv1alpha1.TypeProgressing,
+							Status: metav1.ConditionFalse,
+							Reason: catalogdv1alpha1.ReasonSucceeded,
+						},
+					},
+				},
 			},
 			expectedCatalog: &catalogdv1alpha1.ClusterCatalog{
 				ObjectMeta: metav1.ObjectMeta{
@@ -477,11 +431,26 @@ func TestCatalogdControllerReconcile(t *testing.T) {
 						},
 					},
 				},
+				Status: catalogdv1alpha1.ClusterCatalogStatus{
+					ContentURL: "",
+					Conditions: []metav1.Condition{
+						{
+							Type:   catalogdv1alpha1.TypeServing,
+							Status: metav1.ConditionFalse,
+							Reason: catalogdv1alpha1.ReasonUnavailable,
+						},
+						{
+							Type:   catalogdv1alpha1.TypeProgressing,
+							Status: metav1.ConditionFalse,
+							Reason: catalogdv1alpha1.ReasonSucceeded,
+						},
+					},
+				},
 			},
 		},
 		{
-			name:      "storage finalizer set, catalog deletion timestamp is not zero (or nil), storage delete failed, error returned and finalizer not removed",
-			shouldErr: true,
+			name:          "storage finalizer set, catalog deletion timestamp is not zero (or nil), storage delete failed, error returned, finalizer not removed and catalog continues serving",
+			expectedError: fmt.Errorf("mockstore delete error"),
 			source: &MockSource{
 				result: &source.Result{
 					State: source.StateUnpacked,
@@ -505,6 +474,92 @@ func TestCatalogdControllerReconcile(t *testing.T) {
 						},
 					},
 				},
+				Status: catalogdv1alpha1.ClusterCatalogStatus{
+					ContentURL: "URL",
+					Conditions: []metav1.Condition{
+						{
+							Type:   catalogdv1alpha1.TypeProgressing,
+							Status: metav1.ConditionFalse,
+							Reason: catalogdv1alpha1.ReasonSucceeded,
+						},
+						{
+							Type:   catalogdv1alpha1.TypeServing,
+							Status: metav1.ConditionTrue,
+							Reason: catalogdv1alpha1.ReasonAvailable,
+						},
+					},
+				},
+			},
+			expectedCatalog: &catalogdv1alpha1.ClusterCatalog{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "catalog",
+					Finalizers:        []string{fbcDeletionFinalizer},
+					DeletionTimestamp: &metav1.Time{Time: time.Date(2023, time.October, 10, 4, 19, 0, 0, time.UTC)},
+				},
+				Spec: catalogdv1alpha1.ClusterCatalogSpec{
+					Source: catalogdv1alpha1.CatalogSource{
+						Type: "image",
+						Image: &catalogdv1alpha1.ImageSource{
+							Ref: "someimage:latest",
+						},
+					},
+				},
+				Status: catalogdv1alpha1.ClusterCatalogStatus{
+					ContentURL: "URL",
+					Conditions: []metav1.Condition{
+						{
+							Type:   catalogdv1alpha1.TypeProgressing,
+							Status: metav1.ConditionTrue,
+							Reason: catalogdv1alpha1.ReasonRetrying,
+						},
+						{
+							Type:   catalogdv1alpha1.TypeServing,
+							Status: metav1.ConditionTrue,
+							Reason: catalogdv1alpha1.ReasonAvailable,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:          "storage finalizer set, catalog deletion timestamp is not zero (or nil), unpack cleanup failed, error returned, finalizer not removed but catalog stops serving",
+			expectedError: fmt.Errorf("mocksource cleanup error"),
+			source: &MockSource{
+				unpackError:  nil,
+				cleanupError: fmt.Errorf("mocksource cleanup error"),
+			},
+			store: &MockStore{
+				shouldError: false,
+			},
+			catalog: &catalogdv1alpha1.ClusterCatalog{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "catalog",
+					Finalizers:        []string{fbcDeletionFinalizer},
+					DeletionTimestamp: &metav1.Time{Time: time.Date(2023, time.October, 10, 4, 19, 0, 0, time.UTC)},
+				},
+				Spec: catalogdv1alpha1.ClusterCatalogSpec{
+					Source: catalogdv1alpha1.CatalogSource{
+						Type: "image",
+						Image: &catalogdv1alpha1.ImageSource{
+							Ref: "someimage:latest",
+						},
+					},
+				},
+				Status: catalogdv1alpha1.ClusterCatalogStatus{
+					ContentURL: "URL",
+					Conditions: []metav1.Condition{
+						{
+							Type:   catalogdv1alpha1.TypeProgressing,
+							Status: metav1.ConditionFalse,
+							Reason: catalogdv1alpha1.ReasonSucceeded,
+						},
+						{
+							Type:   catalogdv1alpha1.TypeServing,
+							Status: metav1.ConditionTrue,
+							Reason: catalogdv1alpha1.ReasonAvailable,
+						},
+					},
+				},
 			},
 			expectedCatalog: &catalogdv1alpha1.ClusterCatalog{
 				ObjectMeta: metav1.ObjectMeta{
@@ -523,9 +578,14 @@ func TestCatalogdControllerReconcile(t *testing.T) {
 				Status: catalogdv1alpha1.ClusterCatalogStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:   catalogdv1alpha1.TypeDelete,
+							Type:   catalogdv1alpha1.TypeProgressing,
+							Status: metav1.ConditionTrue,
+							Reason: catalogdv1alpha1.ReasonRetrying,
+						},
+						{
+							Type:   catalogdv1alpha1.TypeServing,
 							Status: metav1.ConditionFalse,
-							Reason: catalogdv1alpha1.ReasonStorageDeleteFailed,
+							Reason: catalogdv1alpha1.ReasonUnavailable,
 						},
 						{
 							Type:   catalogdv1alpha1.TypeUnpacked,
@@ -557,13 +617,10 @@ func TestCatalogdControllerReconcile(t *testing.T) {
 
 			res, err := reconciler.reconcile(ctx, tt.catalog)
 			assert.Equal(t, ctrl.Result{}, res)
-
-			if !tt.shouldErr {
-				assert.NoError(t, err)
-			} else {
-				assert.Error(t, err)
-			}
-			diff := cmp.Diff(tt.expectedCatalog, tt.catalog, cmpopts.IgnoreFields(metav1.Condition{}, "Message", "LastTransitionTime"))
+			assert.Equal(t, tt.expectedError, err)
+			diff := cmp.Diff(tt.expectedCatalog, tt.catalog,
+				cmpopts.IgnoreFields(metav1.Condition{}, "Message", "LastTransitionTime"),
+				cmpopts.SortSlices(func(a, b metav1.Condition) bool { return a.Type < b.Type }))
 			assert.Empty(t, diff, "comparing the expected Catalog")
 		})
 	}
@@ -616,6 +673,11 @@ func TestPollingRequeue(t *testing.T) {
 				Unpacker: &MockSource{result: &source.Result{
 					State: source.StateUnpacked,
 					FS:    &fstest.MapFS{},
+					ResolvedSource: &catalogdv1alpha1.ResolvedCatalogSource{
+						Image: &catalogdv1alpha1.ResolvedImageSource{
+							Ref: "someImage@someSHA256Digest",
+						},
+					},
 				}},
 				Storage: &MockStore{},
 			}
@@ -675,9 +737,14 @@ func TestPollingReconcilerUnpack(t *testing.T) {
 					ContentURL: "URL",
 					Conditions: []metav1.Condition{
 						{
-							Type:   catalogdv1alpha1.TypeUnpacked,
+							Type:   catalogdv1alpha1.TypeProgressing,
+							Status: metav1.ConditionFalse,
+							Reason: catalogdv1alpha1.ReasonSucceeded,
+						},
+						{
+							Type:   catalogdv1alpha1.TypeServing,
 							Status: metav1.ConditionTrue,
-							Reason: catalogdv1alpha1.ReasonUnpackSuccessful,
+							Reason: catalogdv1alpha1.ReasonAvailable,
 						},
 					},
 					ObservedGeneration: 2,
@@ -713,9 +780,14 @@ func TestPollingReconcilerUnpack(t *testing.T) {
 					ContentURL: "URL",
 					Conditions: []metav1.Condition{
 						{
-							Type:   catalogdv1alpha1.TypeUnpacked,
+							Type:   catalogdv1alpha1.TypeProgressing,
+							Status: metav1.ConditionFalse,
+							Reason: catalogdv1alpha1.ReasonSucceeded,
+						},
+						{
+							Type:   catalogdv1alpha1.TypeServing,
 							Status: metav1.ConditionTrue,
-							Reason: catalogdv1alpha1.ReasonUnpackSuccessful,
+							Reason: catalogdv1alpha1.ReasonAvailable,
 						},
 					},
 					ObservedGeneration: 2,
@@ -751,9 +823,14 @@ func TestPollingReconcilerUnpack(t *testing.T) {
 					ContentURL: "URL",
 					Conditions: []metav1.Condition{
 						{
-							Type:   catalogdv1alpha1.TypeUnpacked,
+							Type:   catalogdv1alpha1.TypeProgressing,
+							Status: metav1.ConditionFalse,
+							Reason: catalogdv1alpha1.ReasonSucceeded,
+						},
+						{
+							Type:   catalogdv1alpha1.TypeServing,
 							Status: metav1.ConditionTrue,
-							Reason: catalogdv1alpha1.ReasonUnpackSuccessful,
+							Reason: catalogdv1alpha1.ReasonAvailable,
 						},
 					},
 					ObservedGeneration: 2,
@@ -789,9 +866,14 @@ func TestPollingReconcilerUnpack(t *testing.T) {
 					ContentURL: "URL",
 					Conditions: []metav1.Condition{
 						{
-							Type:   catalogdv1alpha1.TypeUnpacked,
+							Type:   catalogdv1alpha1.TypeProgressing,
+							Status: metav1.ConditionFalse,
+							Reason: catalogdv1alpha1.ReasonSucceeded,
+						},
+						{
+							Type:   catalogdv1alpha1.TypeServing,
 							Status: metav1.ConditionTrue,
-							Reason: catalogdv1alpha1.ReasonUnpackSuccessful,
+							Reason: catalogdv1alpha1.ReasonAvailable,
 						},
 					},
 					ObservedGeneration: 2,
@@ -811,7 +893,7 @@ func TestPollingReconcilerUnpack(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			reconciler := &ClusterCatalogReconciler{
 				Client:   nil,
-				Unpacker: &MockSource{shouldError: true},
+				Unpacker: &MockSource{unpackError: errors.New("mocksource error")},
 				Storage:  &MockStore{},
 			}
 			var err error

--- a/internal/source/unpacker.go
+++ b/internal/source/unpacker.go
@@ -58,18 +58,7 @@ type Result struct {
 
 type State string
 
-const (
-	// StatePending conveys that a request for unpacking a catalog has been
-	// acknowledged, but not yet started.
-	StatePending State = "Pending"
-
-	// StateUnpacking conveys that the source is currently unpacking a catalog.
-	// This state should be used when the catalog contents are being downloaded
-	// and processed.
-	StateUnpacking State = "Unpacking"
-
-	// StateUnpacked conveys that the catalog has been successfully unpacked.
-	StateUnpacked State = "Unpacked"
-)
+// StateUnpacked conveys that the catalog has been successfully unpacked.
+const StateUnpacked State = "Unpacked"
 
 const UnpackCacheDir = "unpack"

--- a/scripts/install.tpl.sh
+++ b/scripts/install.tpl.sh
@@ -39,4 +39,4 @@ kubectl apply -f "${catalogd_manifest}"
 kubectl_wait "olmv1-system" "deployment/catalogd-controller-manager" "60s"
 
 kubectl apply -f "${default_catalogs}"
-kubectl wait --for=condition=Unpacked "clustercatalog/operatorhubio" --timeout="60s"
+kubectl wait --for=condition=Serving "clustercatalog/operatorhubio" --timeout="60s"

--- a/test/e2e/unpack_test.go
+++ b/test/e2e/unpack_test.go
@@ -69,10 +69,10 @@ var _ = Describe("ClusterCatalog Unpacking", func() {
 			Eventually(func(g Gomega) {
 				err := c.Get(ctx, types.NamespacedName{Name: catalog.Name}, catalog)
 				g.Expect(err).ToNot(HaveOccurred())
-				cond := meta.FindStatusCondition(catalog.Status.Conditions, catalogd.TypeUnpacked)
+				cond := meta.FindStatusCondition(catalog.Status.Conditions, catalogd.TypeProgressing)
 				g.Expect(cond).ToNot(BeNil())
-				g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
-				g.Expect(cond.Reason).To(Equal(catalogd.ReasonUnpackSuccessful))
+				g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(cond.Reason).To(Equal(catalogd.ReasonSucceeded))
 			}).Should(Succeed())
 
 			By("Checking that it has an appropriate name label")
@@ -87,6 +87,16 @@ var _ = Describe("ClusterCatalog Unpacking", func() {
 			expectedFBC, err := os.ReadFile("../../testdata/catalogs/test-catalog/expected_all.json")
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(cmp.Diff(expectedFBC, actualFBC)).To(BeEmpty())
+
+			By("Ensuring ClusterCatalog has Status.Condition of Type = Serving with a status == True")
+			Eventually(func(g Gomega) {
+				err := c.Get(ctx, types.NamespacedName{Name: catalog.Name}, catalog)
+				g.Expect(err).ToNot(HaveOccurred())
+				cond := meta.FindStatusCondition(catalog.Status.Conditions, catalogd.TypeServing)
+				g.Expect(cond).ToNot(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+				g.Expect(cond.Reason).To(Equal(catalogd.ReasonAvailable))
+			}).Should(Succeed())
 		})
 		AfterEach(func() {
 			Expect(c.Delete(ctx, catalog)).To(Succeed())


### PR DESCRIPTION
[RFC: ClusterCatalog Status Conditions](https://docs.google.com/document/d/1Kg8ovX8d25OqGa5utwcKbX3nN3obBl2KIYJHYz6IlKU/edit) implementation.

Closes [363](https://github.com/operator-framework/catalogd/issues/363) Closes [364](https://github.com/operator-framework/catalogd/issues/364) Closes [365](https://github.com/operator-framework/catalogd/issues/365)

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->
