### PR TITLE
:bug: Fix matchConditions to be compatible with GenerateName

### DIFF
--- a/config/base/manager/webhook/patch.yaml
+++ b/config/base/manager/webhook/patch.yaml
@@ -8,8 +8,13 @@
 - op: add
   path: /webhooks/0/clientConfig/service/port
   value: 443
+# Make sure there's a name defined, otherwise, we can't create a label. This could happen when generateName is set
+# Then, if any of the conditions are true, create the label:
+# 1. No labels exist
+# 2. The olm.operatorframework.io/metadata.name label doesn't exist
+# 3. The olm.operatorframework.io/metadata.name label doesn't match the name
 - op: add
   path: /webhooks/0/matchConditions
   value:
     - name: MissingOrIncorrectMetadataNameLabel
-      expression: "!has(object.metadata.labels) || !('olm.operatorframework.io/metadata.name' in object.metadata.labels) || object.metadata.labels['olm.operatorframework.io/metadata.name'] != object.metadata.name"
+      expression: "'name' in object.metadata && (!has(object.metadata.labels) || !('olm.operatorframework.io/metadata.name' in object.metadata.labels) || object.metadata.labels['olm.operatorframework.io/metadata.name'] != object.metadata.name)"


### PR DESCRIPTION
This makes sure we have a `name` for the resource... the only way this could happen is if `generateName` is in use. In that case, k8s will update the resource with a `name`, and we'll catch it in the webhook after that happens.
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->
