### PR TITLE
:seedling: Force a rename of the catalogd certificate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ deploy: export MANIFEST="./catalogd.yaml"
 deploy: export DEFAULT_CATALOGS="./config/base/default/clustercatalogs/default-catalogs.yaml"
 deploy: $(KUSTOMIZE) ## Deploy Catalogd to the K8s cluster specified in ~/.kube/config with cert-manager and default clustercatalogs
 	cd config/base/manager && $(KUSTOMIZE) edit set image controller=$(IMAGE) && cd ../../..
-	$(KUSTOMIZE) build config/overlays/cert-manager > catalogd.yaml
+	$(KUSTOMIZE) build config/overlays/cert-manager | sed "s/cert-git-version/cert-$(GIT_VERSION)/g" > catalogd.yaml
 	envsubst '$$CERT_MGR_VERSION,$$MANIFEST,$$DEFAULT_CATALOGS' < scripts/install.tpl.sh | bash -s
 
 .PHONY: only-deploy-manifest
@@ -242,7 +242,7 @@ release: $(GORELEASER) ## Runs goreleaser for catalogd. By default, this will ru
 quickstart: export MANIFEST := https://github.com/operator-framework/catalogd/releases/download/$(VERSION)/catalogd.yaml
 quickstart: export DEFAULT_CATALOGS := https://github.com/operator-framework/catalogd/releases/download/$(VERSION)/default-catalogs.yaml
 quickstart: $(KUSTOMIZE) generate ## Generate the installation release manifests and scripts
-	$(KUSTOMIZE) build config/overlays/cert-manager | sed "s/:devel/:$(GIT_VERSION)/g" > catalogd.yaml
+	$(KUSTOMIZE) build config/overlays/cert-manager | sed "s/:devel/:$(GIT_VERSION)/g" | sed "s/cert-git-version/cert-$(GIT_VERSION)/g" > catalogd.yaml
 	envsubst '$$CERT_MGR_VERSION,$$MANIFEST,$$DEFAULT_CATALOGS' < scripts/install.tpl.sh > install.sh
 
 .PHONY: demo-update

--- a/config/components/tls/patches/manager_deployment_certs.yaml
+++ b/config/components/tls/patches/manager_deployment_certs.yaml
@@ -1,6 +1,6 @@
 - op: add
   path: /spec/template/spec/volumes/-
-  value: {"name":"catalogserver-certs", "secret":{"secretName":"catalogd-catalogserver-cert"}}
+  value: {"name":"catalogserver-certs", "secret":{"secretName":"catalogd-catalogserver-cert-git-version"}}
 - op: add
   path: /spec/template/spec/containers/1/volumeMounts/-
   value: {"name":"catalogserver-certs", "mountPath":"/var/certs"}

--- a/config/components/tls/resources/certificate.yaml
+++ b/config/components/tls/resources/certificate.yaml
@@ -5,7 +5,7 @@ metadata:
   name: catalogserver-cert
   namespace: system
 spec:
-  secretName: catalogd-catalogserver-cert
+  secretName: catalogd-catalogserver-cert-git-version
   dnsNames:
     - localhost
     - catalogd-catalogserver.olmv1-system.svc


### PR DESCRIPTION
This will cause the catalogd deployment to restart, meaning that the catalogd will update quicker (rather than waiting on k8s to update the certificates via the volume)

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->
