### PR TITLE
🐛 Avoid a network call for digest based images

### DIFF
--- a/internal/source/image_registry_client.go
+++ b/internal/source/image_registry_client.go
@@ -92,17 +92,16 @@ func (i *ImageRegistry) Unpack(ctx context.Context, catalog *catalogdv1alpha1.Cl
 		remoteOpts = append(remoteOpts, remote.WithTransport(tlsTransport))
 	}
 
-	// always fetch the hash
-	imgDesc, err := remote.Head(imgRef, remoteOpts...)
+	digestHex, err := resolveDigest(imgRef, remoteOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching image descriptor: %w", err)
 	}
-	l.V(1).Info("resolved image descriptor", "digest", imgDesc.Digest.String())
+	l.V(1).Info("resolved image descriptor", "digest", digestHex)
 
-	unpackPath := filepath.Join(i.BaseCachePath, catalog.Name, imgDesc.Digest.Hex)
-	resolvedRef := fmt.Sprintf("%s@sha256:%s", imgRef.Context().Name(), imgDesc.Digest.Hex)
+	unpackPath := filepath.Join(i.BaseCachePath, catalog.Name, digestHex)
+	resolvedRef := fmt.Sprintf("%s@sha256:%s", imgRef.Context().Name(), digestHex)
 	if stat, err := os.Stat(unpackPath); err == nil && stat.IsDir() {
-		l.V(1).Info("found image in filesystem cache", "digest", imgDesc.Digest.Hex)
+		l.V(1).Info("found image in filesystem cache", "digest", digestHex)
 		// TODO: https://github.com/operator-framework/catalogd/issues/389
 		return unpackedResult(os.DirFS(unpackPath), catalog, resolvedRef, metav1.Time{Time: time.Now()}), nil
 	}
@@ -162,6 +161,23 @@ func unpackedResult(fsys fs.FS, catalog *catalogdv1alpha1.ClusterCatalog, ref st
 		},
 		State: StateUnpacked,
 	}
+}
+
+// resolveDigest returns hex value of the digest for image reference
+func resolveDigest(imgRef name.Reference, remoteOpts ...remote.Option) (string, error) {
+	digest, isDigest := imgRef.(name.Digest)
+	if isDigest {
+		digestHex := strings.TrimPrefix(digest.DigestStr(), "sha256:")
+		// If the reference is already a digest - return without making a network call
+		return digestHex, nil
+	}
+
+	imgDesc, err := remote.Head(imgRef, remoteOpts...)
+	if err != nil {
+		return "", err
+	}
+
+	return imgDesc.Digest.Hex, nil
 }
 
 // unpackImage unpacks a catalog image reference to the provided unpackPath,


### PR DESCRIPTION
While fixing a bug in #394 I removed optimisation for digest based image. This PR changes the unpacker so that we do not make a network call for these images: only for tag-based images.