### PR TITLE
🌱 make post-upgrade-e2e checks wait for ClusterCatalog to be reconciled

### DIFF
--- a/config/base/manager/manager.yaml
+++ b/config/base/manager/manager.yaml
@@ -12,9 +12,10 @@ kind: Deployment
 metadata:
   name: controller-manager
   namespace: system
+  annotations:
+    kubectl.kubernetes.io/default-logs-container: manager
   labels:
-    app.kubernetes.io/part-of: olm
-    app.kubernetes.io/name: catalogd
+    control-plane: catalogd-controller-manager
 spec:
   selector:
     matchLabels:

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/prometheus/client_golang v1.20.3
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0
+	k8s.io/api v0.31.1
 	k8s.io/apiextensions-apiserver v0.31.1
 	k8s.io/apimachinery v0.31.1
 	k8s.io/apiserver v0.31.1
@@ -156,7 +157,6 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.31.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect

--- a/internal/controllers/core/clustercatalog_controller.go
+++ b/internal/controllers/core/clustercatalog_controller.go
@@ -63,6 +63,10 @@ type ClusterCatalogReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.11.0/pkg/reconcile
 func (r *ClusterCatalogReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	l := log.FromContext(ctx).WithName("catalogd-controller")
+	ctx = log.IntoContext(ctx, l)
+
+	l.V(1).Info("reconcile starting")
+	defer l.V(1).Info("reconcile ending")
 
 	existingCatsrc := v1alpha1.ClusterCatalog{}
 	if err := r.Client.Get(ctx, req.NamespacedName, &existingCatsrc); err != nil {


### PR DESCRIPTION
I noticed that the post-upgrade-e2e checks were actually making assertions on the ClusterCatalog before it had a change to be reconciled by the upgraded catalogd instance. This PR should fix that.