### PR TITLE
:bug: Refer to the correct location for go-verdiff

### DIFF
--- a/.github/workflows/go-verdiff.yaml
+++ b/.github/workflows/go-verdiff.yaml
@@ -13,4 +13,4 @@ jobs:
       with:
         fetch-depth: 0
     - name: Check golang version
-      run: hack/tools/check-go-version.sh "${{ github.event.pull_request.base.sha }}"
+      run: hack/scripts/check-go-version.sh "${{ github.event.pull_request.base.sha }}"


### PR DESCRIPTION
The location is different than the operator-controller repo.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->
