### PR TITLE
⚠ Update the Progressing Status condition `Terminal` reason to `Blocked`

### DIFF
--- a/api/core/v1alpha1/clustercatalog_types.go
+++ b/api/core/v1alpha1/clustercatalog_types.go
@@ -37,7 +37,7 @@ const (
 	// Progressing reasons
 	ReasonSucceeded = "Succeeded"
 	ReasonRetrying  = "Retrying"
-	ReasonTerminal  = "Terminal"
+	ReasonBlocked   = "Blocked"
 
 	MetadataNameLabel = "olm.operatorframework.io/metadata.name"
 )

--- a/internal/controllers/core/clustercatalog_controller.go
+++ b/internal/controllers/core/clustercatalog_controller.go
@@ -197,7 +197,7 @@ func updateStatusProgressing(catalog *v1alpha1.ClusterCatalog, err error) {
 
 	if errors.Is(err, reconcile.TerminalError(nil)) {
 		progressingCond.Status = metav1.ConditionFalse
-		progressingCond.Reason = v1alpha1.ReasonTerminal
+		progressingCond.Reason = v1alpha1.ReasonBlocked
 	}
 
 	meta.SetStatusCondition(&catalog.Status.Conditions, progressingCond)

--- a/internal/controllers/core/clustercatalog_controller_test.go
+++ b/internal/controllers/core/clustercatalog_controller_test.go
@@ -121,7 +121,7 @@ func TestCatalogdControllerReconcile(t *testing.T) {
 						{
 							Type:   catalogdv1alpha1.TypeProgressing,
 							Status: metav1.ConditionFalse,
-							Reason: catalogdv1alpha1.ReasonTerminal,
+							Reason: catalogdv1alpha1.ReasonBlocked,
 						},
 					},
 				},
@@ -173,10 +173,10 @@ func TestCatalogdControllerReconcile(t *testing.T) {
 			},
 		},
 		{
-			name:          "valid source type, unpack returns unrecoverable error, status updated to reflect unrecoverable error state and error is returned",
-			expectedError: fmt.Errorf("source bundle content: %w", reconcile.TerminalError(fmt.Errorf("mocksource Unrecoverable error"))),
+			name:          "valid source type, unpack returns terminal error, status updated to reflect terminal error state(Blocked) and error is returned",
+			expectedError: fmt.Errorf("source bundle content: %w", reconcile.TerminalError(fmt.Errorf("mocksource terminal error"))),
 			source: &MockSource{
-				unpackError: reconcile.TerminalError(errors.New("mocksource Unrecoverable error")),
+				unpackError: reconcile.TerminalError(errors.New("mocksource terminal error")),
 			},
 			store: &MockStore{},
 			catalog: &catalogdv1alpha1.ClusterCatalog{
@@ -211,7 +211,7 @@ func TestCatalogdControllerReconcile(t *testing.T) {
 						{
 							Type:   catalogdv1alpha1.TypeProgressing,
 							Status: metav1.ConditionFalse,
-							Reason: catalogdv1alpha1.ReasonTerminal,
+							Reason: catalogdv1alpha1.ReasonBlocked,
 						},
 					},
 				},


### PR DESCRIPTION
Closes [412](https://github.com/operator-framework/catalogd/issues/412)

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->
