### PR TITLE
:bug: Fix wait in pre-upgrade-setup test

### DIFF
--- a/test/tools/imageregistry/pre-upgrade-setup.sh
+++ b/test/tools/imageregistry/pre-upgrade-setup.sh
@@ -31,4 +31,4 @@ spec:
       ref: ${TEST_CLUSTER_CATALOG_IMAGE}
 EOF
 
-kubectl wait --for=condition=Unpacked --timeout=60s ClusterCatalog $TEST_CLUSTER_CATALOG_NAME
+kubectl wait --for=condition=Serving --timeout=60s ClusterCatalog "$TEST_CLUSTER_CATALOG_NAME"


### PR DESCRIPTION
The upgrade e2e test script was still waiting for the catalog to be unpacked