### PR TITLE
🐛clustercatalog_controller: hacky, but more correct status updating in reconciler

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -226,17 +226,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	clusterCatalogFinalizers, err := corecontrollers.NewFinalizers(localStorage, unpacker)
-	if err != nil {
-		setupLog.Error(err, "unable to configure finalizers")
-		os.Exit(1)
-	}
-
 	if err = (&corecontrollers.ClusterCatalogReconciler{
-		Client:     mgr.GetClient(),
-		Unpacker:   unpacker,
-		Storage:    localStorage,
-		Finalizers: clusterCatalogFinalizers,
+		Client:   mgr.GetClient(),
+		Unpacker: unpacker,
+		Storage:  localStorage,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterCatalog")
 		os.Exit(1)

--- a/internal/source/containers_image.go
+++ b/internal/source/containers_image.go
@@ -162,13 +162,23 @@ func successResult(unpackPath string, canonicalRef reference.Canonical, lastUnpa
 		ResolvedSource: &catalogdv1alpha1.ResolvedCatalogSource{
 			Type: catalogdv1alpha1.SourceTypeImage,
 			Image: &catalogdv1alpha1.ResolvedImageSource{
-				Ref:                       canonicalRef.String(),
-				LastSuccessfulPollAttempt: metav1.NewTime(time.Now()),
+				Ref: canonicalRef.String(),
+
+				// We truncate to the second because metav1.Time is serialized
+				// as RFC 3339 which only has second-level precision. When we
+				// use this result in a comparison with what we deserialized
+				// from the Kubernetes API server, we need it to match.
+				LastSuccessfulPollAttempt: metav1.NewTime(time.Now().Truncate(time.Second)),
 			},
 		},
-		State:      StateUnpacked,
-		Message:    fmt.Sprintf("unpacked %q successfully", canonicalRef),
-		UnpackTime: lastUnpacked,
+		State:   StateUnpacked,
+		Message: fmt.Sprintf("unpacked %q successfully", canonicalRef),
+
+		// We truncate to the second because metav1.Time is serialized
+		// as RFC 3339 which only has second-level precision. When we
+		// use this result in a comparison with what we deserialized
+		// from the Kubernetes API server, we need it to match.
+		UnpackTime: lastUnpacked.Truncate(time.Second),
 	}
 }
 

--- a/internal/source/containers_image_test.go
+++ b/internal/source/containers_image_test.go
@@ -396,7 +396,7 @@ func TestImageRegistry(t *testing.T) {
 				// If the digest should already exist check that we actually hit it
 				if tt.digestAlreadyExists {
 					assert.Contains(t, buf.String(), "image already unpacked")
-					assert.Equal(t, rs.UnpackTime, unpackDirStat.ModTime())
+					assert.Equal(t, rs.UnpackTime, unpackDirStat.ModTime().Truncate(time.Second))
 				} else if tt.oldDigestExists {
 					assert.NotContains(t, buf.String(), "image already unpacked")
 					assert.NotEqual(t, rs.UnpackTime, oldDigestModTime)


### PR DESCRIPTION
For awhile in catalogd, we've had a very loose "needsUnpack" behavior where we would make the assumption that if we didn't need to unpack, then we _also_ didn't need to update the status of the object.

This means that some objects may _never_ have their status updated after an upgrade. That's problematic because upgrades may add new helpful fields or fix bugs in the way that status is reported.

This PR is a somewhat hacky fix for the situation. It solves the problem by keeping an in-memory map of the observedGeneration and resolved source, and then using _that_ as the source of truth to and then use that expected status as part of the determination of whether an unpack is required.

A new criteria of "needsUnpack" is now: "does the expected status differ from the status that is on the object. If so, unpack again.

Fixes #422 
Fixes #420 

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->
