### PR TITLE
🐛 Fix pulling signed images

### DIFF
--- a/internal/source/containers_image.go
+++ b/internal/source/containers_image.go
@@ -131,6 +131,12 @@ func (i *ContainersImageRegistry) Unpack(ctx context.Context, catalog *catalogdv
 	//////////////////////////////////////////////////////
 	if _, err := copy.Image(ctx, policyContext, layoutRef, dockerRef, &copy.Options{
 		SourceCtx: srcCtx,
+		// We use the OCI layout as a temporary storage and
+		// pushing signatures for OCI images is not supported
+		// so we remove the source signatures when copying.
+		// Signature validation will still be performed
+		// accordingly to a provided policy context.
+		RemoveSignatures: true,
 	}); err != nil {
 		return nil, fmt.Errorf("error copying image: %w", err)
 	}


### PR DESCRIPTION
This fixes "pushing signatures for OCI images is not supported" error when working with signed source images.

If policy context requires signature validation for a registry we will still be performing it on pull, but we will be removing source signatures when copying into a temporary OCI layout for unpacking.