### PR TITLE
🐛 Check cluster is running for non-standalone Make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ FOCUS := $(if $(TEST),-v -focus "$(TEST)")
 ifeq ($(origin E2E_FLAGS), undefined)
 E2E_FLAGS :=
 endif
-test-e2e: check-kind-cluster $(GINKGO) ## Run the e2e tests on existing cluster
+test-e2e: check-cluster $(GINKGO) ## Run the e2e tests on existing cluster
 	$(GINKGO) $(E2E_FLAGS) -trace -vv $(FOCUS) test/e2e
 
 e2e: KIND_CLUSTER_NAME := catalogd-e2e
@@ -214,12 +214,12 @@ kind-cluster-cleanup: $(KIND) ## Delete the kind cluster
 	$(KIND) delete cluster --name $(KIND_CLUSTER_NAME)
 
 .PHONY: kind-load
-kind-load: check-kind-cluster $(KIND) ## Load the built images onto the local cluster
+kind-load: check-cluster $(KIND) ## Load the built images onto the local cluster
 	$(KIND) export kubeconfig --name $(KIND_CLUSTER_NAME)
 	$(KIND) load docker-image $(IMAGE) --name $(KIND_CLUSTER_NAME)
 
 .PHONY: install
-install: check-kind-cluster build-container kind-load deploy wait ## Install local catalogd to an existing cluster
+install: check-cluster build-container kind-load deploy wait ## Install local catalogd to an existing cluster
 
 .PHONY: deploy
 deploy: export MANIFEST="./catalogd.yaml"
@@ -229,7 +229,7 @@ deploy: $(KUSTOMIZE) ## Deploy Catalogd to the K8s cluster specified in ~/.kube/
 	$(KUSTOMIZE) build $(KUSTOMIZE_OVERLAY) | sed "s/cert-git-version/cert-$(GIT_VERSION)/g" > catalogd.yaml
 	envsubst '$$CERT_MGR_VERSION,$$MANIFEST,$$DEFAULT_CATALOGS' < scripts/install.tpl.sh | bash -s
 
-.PHONY: check-kind-cluster only-deploy-manifest
+.PHONY: check-cluster only-deploy-manifest
 only-deploy-manifest: $(KUSTOMIZE) ## Deploy just the Catalogd manifest--used in e2e testing where cert-manager is installed in a separate step
 	cd config/base/manager && $(KUSTOMIZE) edit set image controller=$(IMAGE)
 	$(KUSTOMIZE) build $(KUSTOMIZE_OVERLAY) | kubectl apply -f -
@@ -268,9 +268,9 @@ quickstart: $(KUSTOMIZE) generate ## Generate the installation release manifests
 demo-update:
 	hack/scripts/generate-asciidemo.sh
 
-.PHONY: check-kind-cluster
-check-kind-cluster: $(KIND)
-	@if ! $(KIND) get clusters | grep -q $(KIND_CLUSTER_NAME); then \
-		echo "Error: Kind cluster '$(KIND_CLUSTER_NAME)' not found. Use 'run' or 'e2e' targets first."; \
+.PHONY: check-cluster
+check-cluster:
+	if ! kubectl config current-context >/dev/null 2>&1; then \
+		echo "Error: Could not get current Kubernetes context. Use 'run' or 'e2e' targets first."; \
 		exit 1; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ FOCUS := $(if $(TEST),-v -focus "$(TEST)")
 ifeq ($(origin E2E_FLAGS), undefined)
 E2E_FLAGS :=
 endif
-test-e2e: check-kind-cluster $(GINKGO) ## Run the e2e tests
+test-e2e: check-kind-cluster $(GINKGO) ## Run the e2e tests on existing cluster
 	$(GINKGO) $(E2E_FLAGS) -trace -vv $(FOCUS) test/e2e
 
 e2e: KIND_CLUSTER_NAME := catalogd-e2e

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ FOCUS := $(if $(TEST),-v -focus "$(TEST)")
 ifeq ($(origin E2E_FLAGS), undefined)
 E2E_FLAGS :=
 endif
-test-e2e: $(GINKGO) ## Run the e2e tests
+test-e2e: check-kind-cluster $(GINKGO) ## Run the e2e tests
 	$(GINKGO) $(E2E_FLAGS) -trace -vv $(FOCUS) test/e2e
 
 e2e: KIND_CLUSTER_NAME := catalogd-e2e
@@ -214,12 +214,12 @@ kind-cluster-cleanup: $(KIND) ## Delete the kind cluster
 	$(KIND) delete cluster --name $(KIND_CLUSTER_NAME)
 
 .PHONY: kind-load
-kind-load: $(KIND) ## Load the built images onto the local cluster
+kind-load: check-kind-cluster $(KIND) ## Load the built images onto the local cluster
 	$(KIND) export kubeconfig --name $(KIND_CLUSTER_NAME)
 	$(KIND) load docker-image $(IMAGE) --name $(KIND_CLUSTER_NAME)
 
 .PHONY: install
-install: build-container kind-load deploy wait ## Install local catalogd
+install: check-kind-cluster build-container kind-load deploy wait ## Install local catalogd
 
 .PHONY: deploy
 deploy: export MANIFEST="./catalogd.yaml"
@@ -229,7 +229,7 @@ deploy: $(KUSTOMIZE) ## Deploy Catalogd to the K8s cluster specified in ~/.kube/
 	$(KUSTOMIZE) build $(KUSTOMIZE_OVERLAY) | sed "s/cert-git-version/cert-$(GIT_VERSION)/g" > catalogd.yaml
 	envsubst '$$CERT_MGR_VERSION,$$MANIFEST,$$DEFAULT_CATALOGS' < scripts/install.tpl.sh | bash -s
 
-.PHONY: only-deploy-manifest
+.PHONY: check-kind-cluster only-deploy-manifest
 only-deploy-manifest: $(KUSTOMIZE) ## Deploy just the Catalogd manifest--used in e2e testing where cert-manager is installed in a separate step
 	cd config/base/manager && $(KUSTOMIZE) edit set image controller=$(IMAGE)
 	$(KUSTOMIZE) build $(KUSTOMIZE_OVERLAY) | kubectl apply -f -
@@ -267,3 +267,10 @@ quickstart: $(KUSTOMIZE) generate ## Generate the installation release manifests
 .PHONY: demo-update
 demo-update:
 	hack/scripts/generate-asciidemo.sh
+
+.PHONY: check-kind-cluster
+check-kind-cluster: $(KIND)
+	@if ! $(KIND) get clusters | grep -q $(KIND_CLUSTER_NAME); then \
+		echo "Error: Kind cluster '$(KIND_CLUSTER_NAME)' not found. Use 'run' or 'e2e' targets first."; \
+		exit 1; \
+	fi

--- a/Makefile
+++ b/Makefile
@@ -271,6 +271,6 @@ demo-update:
 .PHONY: check-cluster
 check-cluster:
 	if ! kubectl config current-context >/dev/null 2>&1; then \
-		echo "Error: Could not get current Kubernetes context. Use 'run' or 'e2e' targets first."; \
+		echo "Error: Could not get current Kubernetes context. Maybe use 'run' or 'e2e' targets first?"; \
 		exit 1; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ kind-load: check-kind-cluster $(KIND) ## Load the built images onto the local cl
 	$(KIND) load docker-image $(IMAGE) --name $(KIND_CLUSTER_NAME)
 
 .PHONY: install
-install: check-kind-cluster build-container kind-load deploy wait ## Install local catalogd
+install: check-kind-cluster build-container kind-load deploy wait ## Install local catalogd to an existing cluster
 
 .PHONY: deploy
 deploy: export MANIFEST="./catalogd.yaml"


### PR DESCRIPTION
We have several non-standlone Make targets

- test-e2e
- kind-load
- install
- only-deploy-manifest

The above targets rely on Kind to be running. 

Unfortunately, currently, errors returned from the Go code are pretty cryptic. Better would be an explicit catch and error when a  Kind cluster is not found when these targets are run.

Currently we have:

```bash
catalogd checking_kind_running $ make test-e2e
/Users/btofel/go/bin/ginkgo-v2.20.2  -trace -vv  test/e2e
Running Suite: E2E Suite - /Users/btofel/workspace/catalogd/test/e2e
====================================================================
Random Seed: 1729265504

Will run 1 of 1 specs
------------------------------
[BeforeSuite]
/Users/btofel/workspace/catalogd/test/e2e/e2e_suite_test.go:33
  > Enter [BeforeSuite] TOP-LEVEL - /Users/btofel/workspace/catalogd/test/e2e/e2e_suite_test.go:33 @ 10/18/24 11:31:49.369

Ginkgo ran 1 suite in 4.681573708s

Test Suite Failed
make: *** [test-e2e] Error 1
```
wha?

but it would be better to have:
```bash
$ make test-e2e
if ! kubectl config current-context >/dev/null 2>&1; then \
		echo "Error: Could not get current Kubernetes context. Use 'run' or 'e2e' targets first."; \
		exit 1; \
	fi
Error: Could not get current Kubernetes context. Use 'run' or 'e2e' targets first.
make: *** [check-cluster] Error 1
```