### PR TITLE
🐛 use spec's ref instead of canonical ref when copying catalog image

### DIFF
--- a/internal/source/containers_image.go
+++ b/internal/source/containers_image.go
@@ -88,7 +88,7 @@ func (i *ContainersImageRegistry) Unpack(ctx context.Context, catalog *catalogdv
 	// copy.Image can concurrently pull all the layers.
 	//
 	//////////////////////////////////////////////////////
-	dockerRef, err := docker.NewReference(canonicalRef)
+	dockerRef, err := docker.NewReference(imgRef)
 	if err != nil {
 		return nil, fmt.Errorf("error creating source reference: %w", err)
 	}


### PR DESCRIPTION
When used in conjuction with a "tag-only" registries.conf mirror registry configuration, our containers/image unpacker fails. This is because we resolve a canonical ref from the tag, and then use the digest-based reference to actually copy the image, thus thwarting the tag-only configuration.

This commit ensures that we always copy the image using the reference provided in the spec.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->
