### PR TITLE
✨ updating demo to work with cert-manager, README with new demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Catalogd is a Kubernetes extension that unpacks [file-based catalog (FBC)](https
 Catalogd helps customers discover installable content by hosting catalog metadata for Kubernetes extensions, such as Operators and controllers. For more information on the Operator Lifecycle Manager (OLM) v1 suite of microservices, see the [documentation](https://github.com/operator-framework/operator-controller/tree/main/docs) for the Operator Controller.
 
 ## Quickstart DEMO
-[![asciicast](https://asciinema.org/a/624043.svg)](https://asciinema.org/a/624043)
+[![asciicast](https://asciinema.org/a/682344.svg)](https://asciinema.org/a/682344)
 
 ## Quickstart Steps
 Procedure steps marked with an asterisk (`*`) are likely to change with future API updates.

--- a/hack/scripts/demo-script.sh
+++ b/hack/scripts/demo-script.sh
@@ -1,34 +1,39 @@
 #!/usr/bin/env bash
 
-trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
+#
 # Welcome to the catalogd demo
+#
+trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
+
+
 kind delete cluster
 kind create cluster
 kubectl cluster-info --context kind-kind
 sleep 10
-# install catalogd on the cluster
-# could also `make install` in repo
-kubectl apply -f https://github.com/operator-framework/catalogd/releases/latest/download/catalogd.yaml
-kubectl wait --for=condition=Available -n olmv1-system deploy/catalogd-controller-manager --timeout=60s
-sleep 10
 
-# inspect crds (catalog)
+# use the install script from the latest github release
+curl -L -s https://github.com/operator-framework/catalogd/releases/latest/download/install.sh | bash
+
+# inspect crds (clustercatalog)
 kubectl get crds -A
+kubectl get clustercatalog -A
 
-# create a catalog
-kubectl apply -f config/samples/core_v1alpha1_catalog.yaml
-# shows catalog-sample
-kubectl get catalog -A 
-# waiting for catalog to report ready status
-time kubectl wait --for=condition=Serving catalog/operatorhubio --timeout=1m
+echo "... checking catalogd controller is available"
+kubectl wait --for=condition=Available -n olmv1-system deploy/catalogd-controller-manager --timeout=1m
+echo "... checking clustercatalog is serving"
+kubectl wait --for=condition=Serving clustercatalog/operatorhubio --timeout=60s
+echo "... checking clustercatalog is finished unpacking"
+kubectl wait --for=condition=Progressing=False clustercatalog/operatorhubio --timeout=60s
 
 # port forward the catalogd-service service to interact with the HTTP server serving catalog contents
-(kubectl -n olmv1-system port-forward svc/catalogd-service 8080:80)&
+(kubectl -n olmv1-system port-forward svc/catalogd-service 8081:443)&
+
+sleep 3
 
 # check what 'packages' are available in this catalog
-curl http://localhost:8080/catalogs/operatorhubio/api/v1/all | jq -s '.[] | select(.schema == "olm.package") | .name'
+curl -k https://localhost:8081/catalogs/operatorhubio/api/v1/all | jq -s '.[] | select(.schema == "olm.package") | .name'
 # check what channels are included in the wavefront package
-curl http://localhost:8080/catalogs/operatorhubio/api/v1/all | jq -s '.[] | select(.schema == "olm.channel") | select(.package == "wavefront") | .name'
+curl -k https://localhost:8081/catalogs/operatorhubio/api/v1/all | jq -s '.[] | select(.schema == "olm.channel") | select(.package == "wavefront") | .name'
 # check what bundles are included in the wavefront package
-curl http://localhost:8080/catalogs/operatorhubio/api/v1/all | jq -s '.[] | select(.schema == "olm.bundle") | select(.package == "wavefront") | .name'
+curl -k https://localhost:8081/catalogs/operatorhubio/api/v1/all | jq -s '.[] | select(.schema == "olm.bundle") | select(.package == "wavefront") | .name'
 


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->
demo was not updated to work with the cert-manager changes made earlier.  
In addition, there are some new waits introduced to give some more signal around some (very) intermittent install failures from the install script. 

This script now completely eschews installation via locally-defined resources and relies entirely on the latest release's scripts/manifests to install on the local cluster, so that we have fewer scripts to maintain. 
