### PR TITLE
🐛 fix an erroneous e2e testdata path update

### DIFF
--- a/test/upgrade/unpack_test.go
+++ b/test/upgrade/unpack_test.go
@@ -76,7 +76,7 @@ var _ = Describe("ClusterCatalog Unpacking", func() {
 				g.Expect(cond.Reason).To(Equal(catalogd.ReasonSucceeded))
 			}).Should(Succeed())
 
-			expectedFBC, err := os.ReadFile("../../testdata/catalogs/test-catalog/api/v1/expected_all.json")
+			expectedFBC, err := os.ReadFile("../../testdata/catalogs/test-catalog/expected_all.json")
 			Expect(err).To(Not(HaveOccurred()))
 
 			By("Making sure the catalog content is available via the http server")


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->
When we pushed types updates recently, we totally expected to see the e2e-upgrade test fail since it pulls in the manifests from the latest release, and they changes were breaking.  
However, we missed an erroneous update that was made to the e2e-upgrade test which presumed that the catalog data was an API access (which wasn't).