### PR TITLE
✨ adding additional waits to prevent e2e cert-manager failures

### DIFF
--- a/scripts/install.tpl.sh
+++ b/scripts/install.tpl.sh
@@ -33,8 +33,11 @@ function kubectl_wait() {
 }
 
 kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/${cert_mgr_version}/cert-manager.yaml"
+kubectl_wait "cert-manager" "deployment/cert-manager-cainjector" "60s"
 kubectl_wait "cert-manager" "deployment/cert-manager-webhook" "60s"
-
+kubectl_wait "cert-manager" "deployment/cert-manager" "60s"
+kubectl wait mutatingwebhookconfigurations/cert-manager-webhook --for=jsonpath='{.webhooks[0].clientConfig.caBundle}' --timeout=60s
+kubectl wait validatingwebhookconfigurations/cert-manager-webhook --for=jsonpath='{.webhooks[0].clientConfig.caBundle}' --timeout=60s
 kubectl apply -f "${catalogd_manifest}"
 kubectl_wait "olmv1-system" "deployment/catalogd-controller-manager" "60s"
 


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->
We've encountered cert-manager failures in e2e, installing from release, and running the demo updates.  This introduces some additional waits on cert-manager resources to attempt to reduce these. 
