### PR TITLE
🐛 fixes the upgrade-e2e test with v1 api

### DIFF
--- a/test/upgrade/unpack_test.go
+++ b/test/upgrade/unpack_test.go
@@ -30,7 +30,7 @@ var _ = Describe("ClusterCatalog Unpacking", func() {
 			ctx := context.Background()
 
 			var managerDeployment appsv1.Deployment
-			managerLabelSelector := labels.Set{"control-plane": "catalogdv1-controller-manager"}
+			managerLabelSelector := labels.Set{"control-plane": "catalogd-controller-manager"}
 			By("Checking that the controller-manager deployment is updated")
 			Eventually(func(g Gomega) {
 				var managerDeployments appsv1.DeploymentList
@@ -66,13 +66,13 @@ var _ = Describe("ClusterCatalog Unpacking", func() {
 			Expect(found).To(BeTrue())
 
 			catalog := &catalogdv1.ClusterCatalog{}
-			By("Ensuring ClusterCatalog has Status.Condition of Progressing with a status == False, reason == Succeeded")
+			By("Ensuring ClusterCatalog has Status.Condition of Progressing with a status == True, reason == Succeeded")
 			Eventually(func(g Gomega) {
 				err := c.Get(ctx, types.NamespacedName{Name: testClusterCatalogName}, catalog)
 				g.Expect(err).ToNot(HaveOccurred())
 				cond := meta.FindStatusCondition(catalog.Status.Conditions, catalogdv1.TypeProgressing)
 				g.Expect(cond).ToNot(BeNil())
-				g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 				g.Expect(cond.Reason).To(Equal(catalogdv1.ReasonSucceeded))
 			}).Should(Succeed())
 


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->
This fixes two issues made manifest in testing the upgrade-e2e case subsequent to cutting the new RC. 
1. [here](https://github.com/operator-framework/catalogd/commit/2f96c573d5a8e5197c53f8219f1e32a24d8d4b8a#diff-b104edd120983248771684630cd3f66af28359c829df801a5eea77845d459aa0R33) an accidental label change in the v1 api promotion
2. [here](https://github.com/operator-framework/catalogd/commit/2f96c573d5a8e5197c53f8219f1e32a24d8d4b8a#diff-b104edd120983248771684630cd3f66af28359c829df801a5eea77845d459aa0R69) a location which I failed to update for the new Progressing==True logic for happy path clustercatalog unpacking.  This was masked due to the fact that we knew we were making breaking changes, and the upgrade-e2e test will fail until we have cut a new release.  😞 

