### PR TITLE
🌱  (fix) Revert: Check cluster is running for non-standalone Make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ FOCUS := $(if $(TEST),-v -focus "$(TEST)")
 ifeq ($(origin E2E_FLAGS), undefined)
 E2E_FLAGS :=
 endif
-test-e2e: check-cluster $(GINKGO) ## Run the e2e tests on existing cluster
+test-e2e: $(GINKGO) ## Run the e2e tests
 	$(GINKGO) $(E2E_FLAGS) -trace -vv $(FOCUS) test/e2e
 
 e2e: KIND_CLUSTER_NAME := catalogd-e2e
@@ -214,12 +214,12 @@ kind-cluster-cleanup: $(KIND) ## Delete the kind cluster
 	$(KIND) delete cluster --name $(KIND_CLUSTER_NAME)
 
 .PHONY: kind-load
-kind-load: check-cluster $(KIND) ## Load the built images onto the local cluster
+kind-load: $(KIND) ## Load the built images onto the local cluster
 	$(KIND) export kubeconfig --name $(KIND_CLUSTER_NAME)
 	$(KIND) load docker-image $(IMAGE) --name $(KIND_CLUSTER_NAME)
 
 .PHONY: install
-install: check-cluster build-container kind-load deploy wait ## Install local catalogd to an existing cluster
+install: build-container kind-load deploy wait ## Install local catalogd
 
 .PHONY: deploy
 deploy: export MANIFEST="./catalogd.yaml"
@@ -229,7 +229,7 @@ deploy: $(KUSTOMIZE) ## Deploy Catalogd to the K8s cluster specified in ~/.kube/
 	$(KUSTOMIZE) build $(KUSTOMIZE_OVERLAY) | sed "s/cert-git-version/cert-$(GIT_VERSION)/g" > catalogd.yaml
 	envsubst '$$CERT_MGR_VERSION,$$MANIFEST,$$DEFAULT_CATALOGS' < scripts/install.tpl.sh | bash -s
 
-.PHONY: check-cluster only-deploy-manifest
+.PHONY: only-deploy-manifest
 only-deploy-manifest: $(KUSTOMIZE) ## Deploy just the Catalogd manifest--used in e2e testing where cert-manager is installed in a separate step
 	cd config/base/manager && $(KUSTOMIZE) edit set image controller=$(IMAGE)
 	$(KUSTOMIZE) build $(KUSTOMIZE_OVERLAY) | kubectl apply -f -
@@ -267,10 +267,3 @@ quickstart: $(KUSTOMIZE) generate ## Generate the installation release manifests
 .PHONY: demo-update
 demo-update:
 	hack/scripts/generate-asciidemo.sh
-
-.PHONY: check-cluster
-check-cluster:
-	if ! kubectl config current-context >/dev/null 2>&1; then \
-		echo "Error: Could not get current Kubernetes context. Maybe use 'run' or 'e2e' targets first?"; \
-		exit 1; \
-	fi


### PR DESCRIPTION
Reverts operator-framework/catalogd#437

If we see the logs https://github.com/operator-framework/catalogd/actions/runs/11819448861/job/32929383546 (ci job of PR where the change was introduced), we can see that this check is wrong and is always failing:

![Screenshot 2024-11-18 at 08 16 07](https://github.com/user-attachments/assets/4cc04e49-d3ff-43ff-8b40-28304a7f52f2)

_PS.: I don't think there's a need for this check. Proof of that is that besides it does not work, nothing changed. Therefore, I do not see value in this one.
Instead, I would prefer the targets of this project to be as similar as possible to those of https://github.com/operator-framework/operator-controller so that life for us contributors is easier._ 
