### PR TITLE
:bug: Add check in test-e2e testing to ensure there's a cluster

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1,6 +1,8 @@
 package e2e
 
 import (
+	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -24,6 +26,11 @@ var (
 )
 
 func TestE2E(t *testing.T) {
+	_, err := ctrl.GetConfig()
+	if err != nil {
+		fmt.Println("Error: Could not get current Kubernetes context. Verify the cluster configuration")
+		os.Exit(0)
+	}
 	RegisterFailHandler(Fail)
 	SetDefaultEventuallyTimeout(1 * time.Minute)
 	SetDefaultEventuallyPollingInterval(1 * time.Second)


### PR DESCRIPTION
<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->
