### PR TITLE
🌱 gha: release: only push images for main branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,8 +42,8 @@ jobs:
           echo IMAGE_TAG="${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
           echo GORELEASER_ARGS="--clean" >> $GITHUB_ENV
           echo ENABLE_RELEASE_PIPELINE=true >> $GITHUB_ENV
-        elif [[ $GITHUB_REF == refs/heads/* ]]; then
-          # Branch build.
+        elif [[ $GITHUB_REF == refs/heads/main ]]; then
+          # 'main' branch build.
           echo IMAGE_TAG="$(echo "${GITHUB_REF#refs/heads/}" | sed -r 's|/+|-|g')" >> $GITHUB_ENV
           echo GORELEASER_ARGS="--clean --skip=validate" >> $GITHUB_ENV
         elif [[ $GITHUB_REF == refs/pull/* ]]; then


### PR DESCRIPTION
It looks like ever since we enabled the merge queue, we've been pushing a bunch of merge queue built image tags to quay.

Check out the "gh-readonly-queue-main" tags at https://quay.io/repository/operator-framework/catalogd?tab=tags&tag=latest

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->
