### PR TITLE
:seedling: Add check for client in e2e

### DIFF
--- a/test/e2e/metrics_endpoint_test.go
+++ b/test/e2e/metrics_endpoint_test.go
@@ -23,10 +23,26 @@ func TestCatalogdMetricsExportedEndpoint(t *testing.T) {
 		token     string
 		curlPod   = "curl-metrics"
 		namespace = "olmv1-system"
+		client    = ""
+		clients   = []string{"kubectl", "oc"}
 	)
 
+	t.Log("Looking for k8s client")
+	for _, c := range clients {
+		// Would prefer to use `command -v`, but even that may not be installed!
+		err := exec.Command(c, "version", "--client").Run()
+		if err == nil {
+			client = c
+			break
+		}
+	}
+	if client == "" {
+		t.Skip("k8s client not found, skipping test")
+	}
+	t.Logf("Using %q as k8s client", client)
+
 	t.Log("Creating ClusterRoleBinding for metrics access")
-	cmd := exec.Command("kubectl", "create", "clusterrolebinding", "catalogd-metrics-binding",
+	cmd := exec.Command(client, "create", "clusterrolebinding", "catalogd-metrics-binding",
 		"--clusterrole=catalogd-metrics-reader",
 		"--serviceaccount="+namespace+":catalogd-controller-manager")
 	output, err := cmd.CombinedOutput()
@@ -34,17 +50,17 @@ func TestCatalogdMetricsExportedEndpoint(t *testing.T) {
 
 	defer func() {
 		t.Log("Cleaning up ClusterRoleBinding")
-		_ = exec.Command("kubectl", "delete", "clusterrolebinding", "catalogd-metrics-binding", "--ignore-not-found=true").Run()
+		_ = exec.Command(client, "delete", "clusterrolebinding", "catalogd-metrics-binding", "--ignore-not-found=true").Run()
 	}()
 
 	t.Log("Creating service account token for authentication")
-	tokenCmd := exec.Command("kubectl", "create", "token", "catalogd-controller-manager", "-n", namespace)
+	tokenCmd := exec.Command(client, "create", "token", "catalogd-controller-manager", "-n", namespace)
 	tokenOutput, err := tokenCmd.Output()
 	require.NoError(t, err, "Error creating token: %s", string(tokenOutput))
 	token = string(bytes.TrimSpace(tokenOutput))
 
 	t.Log("Creating a pod to run curl commands")
-	cmd = exec.Command("kubectl", "run", curlPod,
+	cmd = exec.Command(client, "run", curlPod,
 		"--image=curlimages/curl:7.87.0", "-n", namespace,
 		"--restart=Never",
 		"--overrides", `{
@@ -73,17 +89,17 @@ func TestCatalogdMetricsExportedEndpoint(t *testing.T) {
 
 	defer func() {
 		t.Log("Cleaning up curl pod")
-		_ = exec.Command("kubectl", "delete", "pod", curlPod, "-n", namespace, "--ignore-not-found=true").Run()
+		_ = exec.Command(client, "delete", "pod", curlPod, "-n", namespace, "--ignore-not-found=true").Run()
 	}()
 
 	t.Log("Waiting for the curl pod to become ready")
-	waitCmd := exec.Command("kubectl", "wait", "--for=condition=Ready", "pod", curlPod, "-n", namespace, "--timeout=60s")
+	waitCmd := exec.Command(client, "wait", "--for=condition=Ready", "pod", curlPod, "-n", namespace, "--timeout=60s")
 	waitOutput, waitErr := waitCmd.CombinedOutput()
 	require.NoError(t, waitErr, "Error waiting for curl pod to be ready: %s", string(waitOutput))
 
 	t.Log("Validating the metrics endpoint")
 	metricsURL := "https://catalogd-service.olmv1-system.svc.cluster.local:7443/metrics"
-	curlCmd := exec.Command("kubectl", "exec", curlPod, "-n", namespace, "--",
+	curlCmd := exec.Command(client, "exec", curlPod, "-n", namespace, "--",
 		"curl", "-v", "-k", "-H", "Authorization: Bearer "+token, metricsURL)
 	output, err = curlCmd.CombinedOutput()
 	require.NoError(t, err, "Error calling metrics endpoint: %s", string(output))


### PR DESCRIPTION
Depending on how the e2e is run, we may not have a k8s client available.

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->
