### PR TITLE
:bug: Do not use a fixed namespace for metrics tests

### DIFF
--- a/test/e2e/metrics_endpoint_test.go
+++ b/test/e2e/metrics_endpoint_test.go
@@ -108,7 +108,7 @@ func TestCatalogdMetricsExportedEndpoint(t *testing.T) {
 	require.NoError(t, waitErr, "Error waiting for curl pod to be ready: %s", string(waitOutput))
 
 	t.Log("Validating the metrics endpoint")
-	metricsURL := "https://catalogd-service.olmv1-system.svc.cluster.local:7443/metrics"
+	metricsURL := "https://catalogd-service." + namespace + ".svc.cluster.local:7443/metrics"
 	curlCmd := exec.Command(client, "exec", curlPod, "-n", namespace, "--",
 		"curl", "-v", "-k", "-H", "Authorization: Bearer "+token, metricsURL)
 	output, err = curlCmd.CombinedOutput()


### PR DESCRIPTION
Follow op-con's lead on specifying a metrics address

<!--
Please prefix the title of this PR with one of the following icons:

    * ⚠ (:warning:, major/breaking change)
    * ✨ (:sparkles:, minor/compatible change)
    * 🐛 (:bug:, patch/bug fix)
    * 📖 (:book:, docs)
    * 🌱 (:seedling:, other)

-->
